### PR TITLE
feat: Redis 기반 로그인/로그아웃 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.mybatis.spring.boot</groupId>
 			<artifactId>mybatis-spring-boot-starter</artifactId>
 			<version>3.0.5</version>

--- a/src/main/java/com/ssafy/jjtrip/common/config/RedisConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package com.ssafy.jjtrip.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        return new StringRedisTemplate(redisConnectionFactory);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -32,6 +34,11 @@ public class SecurityConfig {
 
     @Value("${security.cors.allowed-origins}")
     private String[] allowedOrigins;
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
@@ -22,10 +22,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final RedisUtil redisUtil; // [추가됨]
+    private final RedisUtil redisUtil;
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
+    public static final String BLACKLIST_PREFIX = "BlackList:";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -36,7 +37,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             jwtTokenProvider.validateToken(token);
 
-            if (redisUtil.hasKeyBlackList("BlackList:" + token)) {
+            if (redisUtil.hasKey(BLACKLIST_PREFIX + token)) {
                 throw new AuthException(AuthErrorCode.JWT_TOKEN_INVALID);
             }
 
@@ -50,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
+            return bearerToken.substring(BEARER_PREFIX.length());
         }
         return null;
     }

--- a/src/main/java/com/ssafy/jjtrip/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/ssafy/jjtrip/common/security/JwtTokenProvider.java
@@ -79,7 +79,7 @@ public class JwtTokenProvider {
         Long userId = claims.get("id", Long.class);
         String nickname = claims.get("nickname", String.class);
         String roleStr = claims.get("role", String.class);
-        Role role = Role.valueOf(roleStr); // String -> Enum 변환
+        Role role = Role.valueOf(roleStr);
 
         Collection<? extends GrantedAuthority> authorities =
                 Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));

--- a/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
+++ b/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
@@ -26,12 +26,4 @@ public class RedisUtil {
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
     }
-
-    public void setBlackList(String key, String value, long expireTimeMs) {
-        stringRedisTemplate.opsForValue().set(key, value, Duration.ofMillis(expireTimeMs));
-    }
-
-    public boolean hasKeyBlackList(String key) {
-        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
-    }
 }

--- a/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
+++ b/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
@@ -1,0 +1,37 @@
+package com.ssafy.jjtrip.common.util;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void set(String key, String value, long expireTimeMs) {
+        stringRedisTemplate.opsForValue().set(key, value, Duration.ofMillis(expireTimeMs));
+    }
+
+    public String get(String key) {
+        return stringRedisTemplate.opsForValue().get(key);
+    }
+
+    public void delete(String key) {
+        stringRedisTemplate.delete(key);
+    }
+
+    public boolean hasKey(String key) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+
+    public void setBlackList(String key, String value, long expireTimeMs) {
+        stringRedisTemplate.opsForValue().set(key, value, Duration.ofMillis(expireTimeMs));
+    }
+
+    public boolean hasKeyBlackList(String key) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/dto/LoginResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/dto/LoginResponseDto.java
@@ -2,6 +2,7 @@ package com.ssafy.jjtrip.domain.auth.dto;
 
 public record LoginResponseDto(
         String accessToken,
+        long expiresIn,
         String email,
         String nickname
 ) {

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/dto/TokenInfo.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/dto/TokenInfo.java
@@ -2,6 +2,7 @@ package com.ssafy.jjtrip.domain.auth.dto;
 
 public record TokenInfo(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        long accessTokenExpiresIn
 ) {
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/dto/TokenResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/dto/TokenResponseDto.java
@@ -1,0 +1,7 @@
+package com.ssafy.jjtrip.domain.auth.dto;
+
+public record TokenResponseDto(
+        String accessToken,
+        long expiresIn
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/exception/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements ErrorCode {
     AUTHENTICATION_FAILED("AUTH_001", "인증에 실패했습니다.", HttpStatus.UNAUTHORIZED),
     JWT_TOKEN_EXPIRED("AUTH_002", "토큰이 만료되었습니다.",HttpStatus.UNAUTHORIZED),
     JWT_TOKEN_INVALID("AUTH_003", "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    REFRESH_TOKEN_NOT_FOUND("AUTH_004", "리프레시 토큰이 없습니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATE_EMAIL("AUTH_005", "이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
 
     private final String code;

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
@@ -1,6 +1,8 @@
 package com.ssafy.jjtrip.domain.auth.service;
 
+import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.common.security.JwtTokenProvider;
+import com.ssafy.jjtrip.common.util.RedisUtil;
 import com.ssafy.jjtrip.domain.auth.dto.SignupRequestDto;
 import com.ssafy.jjtrip.domain.auth.dto.TokenInfo;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
@@ -10,6 +12,8 @@ import com.ssafy.jjtrip.domain.user.entity.User;
 import com.ssafy.jjtrip.domain.user.entity.UserStatus;
 import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -23,21 +27,43 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
+    private final RedisUtil redisUtil;
+
+    @Value("${app.jwt.refresh-token-expire-time}")
+    private long refreshTokenExpireTimeMs;
+
+    @Value("${app.jwt.access-token-expire-time}")
+    private long accessTokenExpireTimeMs;
 
     @Transactional
     public TokenInfo login(String email, String password) {
-        // 1. 인증 시도
         Authentication authentication = authenticate(email, password);
-
-        // 2. 인증된 Authentication 을 SecurityContext 에 저장
         SecurityContextHolder.getContext().setAuthentication(authentication);
+        TokenInfo tokenInfo = issueTokens(authentication);
+        redisUtil.set("RefreshToken:" + email, tokenInfo.refreshToken(), refreshTokenExpireTimeMs);
 
-        // 3. 토큰 발급
-        return issueTokens(authentication);
+        return tokenInfo;
+    }
+
+    @Transactional
+    public void logout(String accessToken) {
+        jwtTokenProvider.validateToken(accessToken);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        String email = authentication.getName();
+
+        if (redisUtil.hasKey("RefreshToken:" + email)) {
+            redisUtil.delete("RefreshToken:" + email);
+        }
+
+        long expiration = jwtTokenProvider.getRemainingExpireTime(accessToken);
+        if (expiration > 0) {
+            redisUtil.setBlackList("BlackList:" + accessToken, "logout", expiration);
+        }
     }
 
     @Transactional
@@ -47,16 +73,39 @@ public class AuthService {
         userMapper.save(user);
     }
 
+    @Transactional
+    public TokenInfo refresh(String refreshToken) {
+        jwtTokenProvider.validateToken(refreshToken);
+
+        String email = jwtTokenProvider.getSubject(refreshToken);
+        String savedToken = redisUtil.get("RefreshToken:" + email);
+        if (savedToken == null || !savedToken.equals(refreshToken)) {
+            throw new AuthException(AuthErrorCode.JWT_TOKEN_INVALID);
+        }
+
+        User user = userMapper.findByEmail(email)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.JWT_TOKEN_INVALID));
+
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+
+        TokenInfo newTokenInfo = issueTokens(authentication);
+        redisUtil.set("RefreshToken:" + email, newTokenInfo.refreshToken(), refreshTokenExpireTimeMs);
+
+        return newTokenInfo;
+    }
+
     private Authentication authenticate(String email, String password) {
         UsernamePasswordAuthenticationToken authToken =
                 new UsernamePasswordAuthenticationToken(email, password);
-        return authenticationManagerBuilder.getObject().authenticate(authToken);
+        return authenticationManager.authenticate(authToken);
     }
 
     private TokenInfo issueTokens(Authentication authentication) {
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
         String refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
-        return new TokenInfo(accessToken, refreshToken);
+
+        return new TokenInfo(accessToken, refreshToken, accessTokenExpireTimeMs);
     }
 
     private void validateDuplicateEmail(String email) {


### PR DESCRIPTION
## Issue
- #6 
- #9 

## Details
이 PR은 기존 JWT 인증 시스템에 Redis 기반의 상태 관리(RT 저장, AT 블랙리스트) 기능을 추가하여 토큰의 생명 주기와 무결성을 서버가 실시간으로 관리하도록 개선했습니다. 

### ✔️ 주요 변경 사항
* **Redis 통합:** Refresh Token(RT) 저장소 및 Access Token(AT) BlackList 구현
* **AT BlackList:** 만료되지 않은 AT를 로그아웃 시, 즉시 무효화 (강제 로그아웃 기능 구현)
* **토큰 재발급:** RT 검증 후 DB 최신 정보를 조회하여 AT/RT를 갱신하는 Token Rotation 로직 구현
* **DTO 개선:** `TokenResponseDto` 분리 및 `LoginRequestDto`, `TokenInfo`에도 AT 만료 시간(`expiresIn`) 추가
* **Security 개선:** Service Layer에서 `AuthenticationManagerBuilder` 대신 `AuthenticationManager` Bean을 활용하여 안정성 확보

---

### 🎯 Redis 기반 인증 흐름

1. **로그인 (Login)**
* Action: 사용자가 ID/PW로 로그인을 요청합니다.
* Result: 서버는 AT(Body)와 새로운 RT(HttpOnly Cookie)를 발급합니다.
* Redis: RT가 `RefreshToken:email` 키로 저장됩니다.

2. **보호 API 요청 및 검증 (Authentication Check)**
* Action: 클라이언트가 AT를 담아서 API를 요청합니다.
* Filter 동작: `JwtAuthenticationFilter`가 토큰을 확인합니다.
* Logic: Redis에 `BlackList:토큰값`이 존재하는지 확인하여 로그아웃된 토큰은 즉시 차단합니다.

3. **로그아웃 (Logout)**
* Action: 사용자가 `/logout`을 요청합니다. (AT 사용)
* Redis 동작:
        * RT는 Redis에서 삭제됩니다. (재발급 차단)
        * AT는 남은 수명만큼 Redis BlackList에 등록됩니다. (강제 무효화)

4. **토큰 재발급 (Refresh)**
* Action: AT 만료 시 클라이언트가 RT(Cookie)로 `/refresh`를 요청합니다.
* Logic: RT와 Redis에 저장된 값을 비교 검증 후, DB에서 최신 사용자 정보를 조회하여 새로운 AT/RT를 발급합니다.

---

### 🕰️ 토큰 만료 시간 관리 방식
매끄러운 UX를 위해 Access Token과 Refresh Token의 만료 시간을 다르게 전달하는 전략을 사용했습니다.

✅ **Access Token 만료 시간 (모든 DTO에 포함)**
* **포함 이유:** Access Token은 만료 시간이 짧기 때문에, 클라이언트(프론트엔드 JavaScript)가 만료 시점을 미리 알고 대비해야 합니다.

* 장점
        * Proactive Refresh: 클라이언트가 expiresIn 타이머를 돌려 토큰 만료 직전에 /refresh API를 자동 호출합니다. 이로 인해 사용자는 401 Unauthorized 에러를 겪지 않고 인증 상태가 유지됩니다.

- `TokenInfo`, `LoginResponseDto`, `TokenResponseDto` 모두에 포함되어 데이터의 일관성을 유지합니다.

❌ **Refresh Token 만료 시간 (모든 DTO에 미포함)**
* **미포함 이유:** Refresh Token은 HttpOnly 쿠키로 전송되어 JavaScript 접근이 원천 차단됩니다. 또한, RT의 만료 시간은 이미 HTTP 헤더의 Set-Cookie 속성(Max-Age 등)을 통해 브라우저 자체에 직접 전달되어 브라우저가 자동으로 쿠키를 삭제합니다.

* 장점
        * 보안성: HttpOnly 원칙을 유지하여 XSS 공격으로부터 보호합니다.
        * DRY (Don't Repeat Yourself, 중복 제거): 이미 Controller 단에서 `application.yml` 설정을 통해 해당 만료 시간을 알고 Cookie에 설정하므로, DTO에 중복하여 담아 전달할 필요가 없습니다.