### PR TITLE
fix: 만료된 Access Token으로 로그아웃 시 발생하는 예외 처리 수정

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/api/auth/login",
                                 "/api/auth/refresh",
-                                "/api/auth/signup"
+                                "/api/auth/signup",
+                                "/api/auth/logout"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
@@ -27,6 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
     public static final String BLACKLIST_PREFIX = "BlackList:";
+    private static final String LOGOUT_URL = "/api/auth/logout";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -35,17 +36,41 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (StringUtils.hasText(token)) {
-            jwtTokenProvider.validateToken(token);
-
-            if (redisUtil.hasKey(BLACKLIST_PREFIX + token)) {
-                throw new AuthException(AuthErrorCode.JWT_TOKEN_INVALID);
+            try {
+                authenticate(token);
+            } catch (AuthException e) {
+                handleAuthException(request, e);
             }
-
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private void authenticate(String token) {
+        jwtTokenProvider.validateToken(token);
+
+        if (redisUtil.hasKey(BLACKLIST_PREFIX + token)) {
+            throw new AuthException(AuthErrorCode.JWT_TOKEN_INVALID);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private void handleAuthException(HttpServletRequest request, AuthException e) {
+        boolean isTokenExpired = e.getErrorCode() == AuthErrorCode.JWT_TOKEN_EXPIRED;
+        boolean isLogoutRequest = isLogoutRequest(request);
+
+        if (!isTokenExpired || !isLogoutRequest) {
+            throw e;
+        }
+
+        log.debug("만료된 Access Token으로 들어온 로그아웃 요청이 감지되었습니다. 검증 절차를 스킵합니다. URI: {}", request.getRequestURI());
+    }
+
+    private boolean isLogoutRequest(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.equals(LOGOUT_URL) || path.equals(LOGOUT_URL + "/");
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
@@ -54,8 +54,6 @@ public class AuthService {
 
     @Transactional
     public void logout(String accessToken) {
-        jwtTokenProvider.validateToken(accessToken);
-
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         String email = authentication.getName();
 


### PR DESCRIPTION
## Issue
- #11 

## Details
이 PR은 **Access Token이 이미 만료된 상태에서도 로그아웃 로직이 정상적으로 수행되도록 예외 처리 로직을 개선**했습니다. 이를 통해 **클라이언트와 서버(Redis) 간의 인증 상태 불일치 문제를 해결**했습니다.

### ✔️ 주요 변경 사항
* Filter 개선: `JwtAuthenticationFilter`에서 로그아웃 요청(`/api/auth/logout`)인 경우, `ExpiredJwtException`이 발생해도 예외를 무시하고 요청을 통과시키도록 수정
* Service 개선: `AuthService` 로그아웃 로직 내 중복된 토큰 검증(`validateToken`) 메서드를 제거

---

### 🎯 개선된 로그아웃 흐름

1. **로그아웃 요청 (Client)**
* Action: 사용자가 만료된 Access Token을 헤더에 담아 `/api/auth/logout`을 요청합니다.

2. **필터 예외 처리 (Filter)**
* Detection: `JwtAuthenticationFilter`가 토큰 만료를 감지(`ExpiredJwtException`)합니다.
* Logic: 요청 URI가 로그아웃임을 확인하면, 에러를 발생시키는 대신 다음 Chain으로 요청을 통과시킵니다.

3. **보안 검사 (Security)**
* Config: 필터 통과 시 SecurityContext가 비어 있는 Anonymous 상태가 되므로, `SecurityConfig`의 `permitAll()` 목록에 `/api/auth/logout`을 추가하여 403 Forbidden 에러 없이 Controller에 진입하도록 설정했습니다.

4. **Redis 정리**
* Action: `AuthService`가 만료된 토큰 내부의 Claims를 파싱하여 Subject(email)를 추출합니다.
* Result: 해당 이메일 키로 지정되어 있는 Refresh Token을 삭제합니다.

---

### 🚧 특이사항
**정상 로직이라면** Access Token이 만료되었을 때 Refresh Token을 활용해 **재발급** 받아야 합니다.
수정하기 이전 코드에서, **로그아웃 API 또한 만료된 Access Token을 재발급 받아 재요청을 보냈어야 합니다.**
하지만 401 에러가 발생했다는 것은 **프론트엔드에서 토큰을 갱신하고 재요청을 보내는 인터셉터 로직이 빠져 있다는 것으로 추측**됩니다.

---

### 📌 정리
* 만료된 Access Token으로 로그아웃 요청이 들어오면 Refresh Token이 삭제되지 않던 오류를 해결했습니다.

---

### 📅 향후 계획
* **Access Token이 만료되었을 때, Refresh Token이 살아 있다면 재발급 받는 기능이 필요**합니다.
    * 프론트엔드에서 자체적으로 Access Token의 만료 여부를 감지하고, 재발급을 요청하는 Proactive Refresh 로직을 추가합니다.