### PR TITLE
feat: 사용자 프로필 사진 관리 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,10 +30,33 @@
 		<java.version>17</java.version>
 		<lombok.version>1.18.32</lombok.version>
 	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.awspring.cloud</groupId>
+				<artifactId>spring-cloud-aws-dependencies</artifactId>
+				<version>3.1.1</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.awspring.cloud</groupId>
+			<artifactId>spring-cloud-aws-starter-s3</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/ssafy/jjtrip/JjtripApplication.java
+++ b/src/main/java/com/ssafy/jjtrip/JjtripApplication.java
@@ -2,10 +2,12 @@ package com.ssafy.jjtrip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync
 @SpringBootApplication
+@ComponentScan(basePackages = "com.ssafy.jjtrip")
 public class JjtripApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
                                 "/api/auth/reset-password",
                                 "/api/auth/logout"
                         ).permitAll()
+                        .requestMatchers("/api/user/**").authenticated()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/ssafy/jjtrip/common/s3/S3Config.java
+++ b/src/main/java/com/ssafy/jjtrip/common/s3/S3Config.java
@@ -1,0 +1,32 @@
+package com.ssafy.jjtrip.common.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/common/s3/S3Service.java
+++ b/src/main/java/com/ssafy/jjtrip/common/s3/S3Service.java
@@ -1,0 +1,86 @@
+package com.ssafy.jjtrip.common.s3;
+
+import com.ssafy.jjtrip.common.s3.exception.FileErrorCode;
+import com.ssafy.jjtrip.common.s3.exception.FileException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+public class S3Service {
+
+    private static final String PROFILE_IMAGE_PREFIX = "public/profile/";
+    private static final String URL_SEPARATOR = "/";
+
+    private final S3Client s3Client;
+    private final String bucketName;
+    private final String baseUrl;
+
+    public S3Service(S3Client s3Client,
+                       @Value("${spring.cloud.aws.s3.bucket}") String bucketName,
+                       @Value("${file.base-url}") String baseUrl) {
+        this.s3Client = s3Client;
+        this.bucketName = bucketName;
+        this.baseUrl = baseUrl;
+    }
+
+    public String uploadProfileImage(MultipartFile file) {
+        if (file.isEmpty()) {
+            throw new FileException(FileErrorCode.EMPTY_FILE);
+        }
+
+        String key = createKey(PROFILE_IMAGE_PREFIX, file.getOriginalFilename());
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .contentLength(file.getSize())
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            throw new FileException(FileErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        return baseUrl + "/" + key;
+    }
+
+    public void deleteImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty() || !imageUrl.startsWith(baseUrl)) {
+            return;
+        }
+        try {
+            String key = extractKeyFromUrl(imageUrl);
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            System.err.println("Failed to delete old S3 image: " + imageUrl + ". Error: " + e.getMessage());
+        }
+    }
+
+    private String createKey(String prefix, String originalFilename) {
+        String ext = StringUtils.getFilenameExtension(originalFilename);
+        if (!StringUtils.hasText(ext)) {
+            throw new FileException(FileErrorCode.INVALID_FILE_EXTENSION);
+        }
+        String uuid = UUID.randomUUID().toString();
+        return prefix + uuid + "." + ext;
+    }
+
+    private String extractKeyFromUrl(String imageUrl) {
+        return imageUrl.substring(baseUrl.length() + URL_SEPARATOR.length());
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/common/s3/exception/FileErrorCode.java
+++ b/src/main/java/com/ssafy/jjtrip/common/s3/exception/FileErrorCode.java
@@ -1,0 +1,19 @@
+package com.ssafy.jjtrip.common.s3.exception;
+
+import com.ssafy.jjtrip.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum FileErrorCode implements ErrorCode {
+
+    FILE_UPLOAD_FAILED("FILE_001", "File upload failed.", HttpStatus.INTERNAL_SERVER_ERROR),
+    EMPTY_FILE("FILE_002", "File is empty.", HttpStatus.BAD_REQUEST),
+    INVALID_FILE_EXTENSION("FILE_003", "Invalid file extension.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/ssafy/jjtrip/common/s3/exception/FileException.java
+++ b/src/main/java/com/ssafy/jjtrip/common/s3/exception/FileException.java
@@ -1,0 +1,11 @@
+package com.ssafy.jjtrip.common.s3.exception;
+
+import com.ssafy.jjtrip.common.exception.BusinessException;
+import com.ssafy.jjtrip.common.exception.ErrorCode;
+
+public class FileException extends BusinessException {
+
+    public FileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.ssafy.jjtrip.domain.auth.dto.*;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.auth.exception.AuthException;
 import com.ssafy.jjtrip.domain.auth.service.AuthService;
+import com.ssafy.jjtrip.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ public class AuthController {
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
     private final AuthService authService;
+    private final UserService userService;
 
     @Value("${app.jwt.refresh-token-expire-time}")
     private long refreshTokenExpireTimeMs;
@@ -75,13 +77,13 @@ public class AuthController {
 
     @PostMapping("/reset-password")
     public ResponseEntity<?> resetPassword(@Valid @RequestBody PasswordResetRequestDto request) {
-        authService.resetPassword(request.email());
+        userService.resetPassword(request.email());
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/find-email/{nickname}")
     public ResponseEntity<?> findEmailByNickname(@PathVariable("nickname") String nickname) {
-        String email = authService.findEmailByNickname(nickname);
+        String email = userService.findEmailByNickname(nickname);
         return ResponseEntity.ok(java.util.Map.of("email", email));
     }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
@@ -1,10 +1,8 @@
 package com.ssafy.jjtrip.domain.auth.service;
 
-import com.ssafy.jjtrip.common.mail.EmailService;
 import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.common.security.JwtTokenProvider;
 import com.ssafy.jjtrip.common.util.RedisUtil;
-import com.ssafy.jjtrip.common.util.EmailMasker;
 import com.ssafy.jjtrip.domain.auth.dto.SignupRequestDto;
 import com.ssafy.jjtrip.domain.auth.dto.TokenInfo;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
@@ -13,7 +11,6 @@ import com.ssafy.jjtrip.domain.user.entity.Role;
 import com.ssafy.jjtrip.domain.user.entity.User;
 import com.ssafy.jjtrip.domain.user.entity.UserStatus;
 import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
-import java.security.SecureRandom;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,7 +36,6 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final UserMapper userMapper;
     private final RedisUtil redisUtil;
-    private final EmailService emailService;
 
     @Value("${app.jwt.refresh-token-expire-time}")
     private long refreshTokenExpireTimeMs;
@@ -78,22 +74,6 @@ public class AuthService {
         validateDuplicateNickname(signupRequestDto.nickname());
         User user = buildNewUser(signupRequestDto);
         userMapper.save(user);
-    }
-
-    @Transactional
-    public void resetPassword(String email) {
-        userMapper.findByEmail(email).ifPresent(user -> {
-            String temporaryPassword = generateTemporaryPassword();
-            String encodedPassword = passwordEncoder.encode(temporaryPassword);
-            userMapper.updatePasswordHash(user.getId(), encodedPassword);
-            emailService.sendNewPasswordEmail(user.getEmail(), temporaryPassword);
-        });
-    }
-
-    public String findEmailByNickname(String nickname) {
-        User user = userMapper.findByNickname(nickname)
-                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
-        return EmailMasker.maskEmail(user.getEmail());
     }
 
     @Transactional
@@ -156,15 +136,5 @@ public class AuthService {
                 .role(Role.USER)
                 .status(UserStatus.ACTIVE)
                 .build();
-    }
-
-    private String generateTemporaryPassword() {
-        final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        SecureRandom random = new SecureRandom();
-        StringBuilder sb = new StringBuilder(10);
-        for (int i = 0; i < 10; i++) {
-            sb.append(chars.charAt(random.nextInt(chars.length())));
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
@@ -1,0 +1,46 @@
+package com.ssafy.jjtrip.domain.user.controller;
+
+import com.ssafy.jjtrip.common.s3.exception.FileErrorCode;
+import com.ssafy.jjtrip.common.s3.exception.FileException;
+import com.ssafy.jjtrip.common.security.CustomUserDetails;
+import com.ssafy.jjtrip.domain.user.dto.response.ProfileImageUpdateResponseDto;
+import com.ssafy.jjtrip.domain.user.dto.response.UserProfileResponseDto;
+import com.ssafy.jjtrip.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponseDto> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserProfileResponseDto user = userService.getUserProfile(userDetails.getUser().getId());
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping("/profile-image")
+    public ResponseEntity<ProfileImageUpdateResponseDto> updateUserProfileImage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam("image") MultipartFile image) {
+
+        if (image == null || image.isEmpty()) {
+            throw new FileException(FileErrorCode.EMPTY_FILE);
+        }
+
+        String newImageUrl = userService.updateUserProfileImage(userDetails.getUser().getId(), image);
+        
+        ProfileImageUpdateResponseDto response = new ProfileImageUpdateResponseDto(newImageUrl);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/ProfileImageUpdateResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/ProfileImageUpdateResponseDto.java
@@ -1,0 +1,10 @@
+package com.ssafy.jjtrip.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProfileImageUpdateResponseDto {
+    private String newImageUrl;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserProfileResponseDto.java
@@ -1,0 +1,13 @@
+package com.ssafy.jjtrip.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserProfileResponseDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
@@ -46,6 +46,21 @@ public interface UserMapper {
     })
     Optional<User> findByNickname(String nickname);
 
+    @Select("SELECT id, role_id, status_id, email, password_hash, nickname, profile_image_url, created_at, updated_at " +
+            "FROM user WHERE id = #{id}")
+    @Results({
+            @Result(property = "id", column = "id"),
+            @Result(property = "role", column = "role_id", javaType = Role.class),
+            @Result(property = "status", column = "status_id", javaType = UserStatus.class),
+            @Result(property = "email", column = "email"),
+            @Result(property = "passwordHash", column = "password_hash"),
+            @Result(property = "nickname", column = "nickname"),
+            @Result(property = "profileImageUrl", column = "profile_image_url"),
+            @Result(property = "createdAt", column = "created_at"),
+            @Result(property = "updatedAt", column = "updated_at")
+    })
+    Optional<User> findById(Long id);
+
     @Insert("INSERT INTO user (role_id, status_id, email, password_hash, nickname) " +
             "VALUES (#{role}, #{status}, #{email}, #{passwordHash}, #{nickname})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
@@ -53,4 +68,7 @@ public interface UserMapper {
 
     @Update("UPDATE user SET password_hash = #{passwordHash} WHERE id = #{userId}")
     void updatePasswordHash(@Param("userId") Long userId, @Param("passwordHash") String passwordHash);
+
+    @Update("UPDATE user SET profile_image_url = #{imageUrl} WHERE id = #{userId}")
+    void updateProfileImageUrl(@Param("userId") Long userId, @Param("imageUrl") String imageUrl);
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
@@ -1,0 +1,89 @@
+package com.ssafy.jjtrip.domain.user.service;
+
+import com.ssafy.jjtrip.common.mail.EmailService;
+import com.ssafy.jjtrip.common.s3.S3Service;
+import com.ssafy.jjtrip.common.util.EmailMasker;
+import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
+import com.ssafy.jjtrip.domain.auth.exception.AuthException;
+import com.ssafy.jjtrip.domain.user.dto.response.UserProfileResponseDto;
+import com.ssafy.jjtrip.domain.user.entity.User;
+import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.security.SecureRandom;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
+    private final S3Service s3Service;
+
+    public User findUserById(Long userId) {
+        return userMapper.findById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+    }
+
+    public UserProfileResponseDto getUserProfile(Long userId) {
+        User user = findUserById(userId);
+        return UserProfileResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+    }
+
+    @Transactional
+    public void resetPassword(String email) {
+        userMapper.findByEmail(email).ifPresent(user -> {
+            String temporaryPassword = generateTemporaryPassword();
+            String encodedPassword = passwordEncoder.encode(temporaryPassword);
+            userMapper.updatePasswordHash(user.getId(), encodedPassword);
+            emailService.sendNewPasswordEmail(user.getEmail(), temporaryPassword);
+        });
+    }
+
+    public String findEmailByNickname(String nickname) {
+        User user = userMapper.findByNickname(nickname)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        return EmailMasker.maskEmail(user.getEmail());
+    }
+
+    @Transactional
+    public String updateUserProfileImage(Long userId, MultipartFile profileImage) {
+
+        User user = findUserById(userId);
+        String oldImageUrl = user.getProfileImageUrl();
+        String newImageUrl = s3Service.uploadProfileImage(profileImage);
+
+        userMapper.updateProfileImageUrl(userId, newImageUrl);
+
+        if (oldImageUrl != null && !oldImageUrl.isEmpty()) {
+            s3Service.deleteImage(oldImageUrl);
+        }
+
+        return newImageUrl;
+    }
+    
+    private String generateTemporaryPassword() {
+
+        final String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+        SecureRandom random = new SecureRandom();
+        StringBuilder sb = new StringBuilder(10);
+        for (int i = 0; i < 10; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Issue
- #18 

## Details
이 PR은 **사용자 프로필 이미지 관리 기능**을 추가하고, 이에 필요한 **AWS S3 연동** 및 **유저 관리 구조를 재정비**하여 UX와 코드 구조를 개선했습니다.

### ✔️ 주요 변경 사항
- **S3 연동 및 파일 처리 관련 의존성을 `pom.xml`에 추가**
- **프로필 이미지 관리 기능 추가**
    - AWS S3 버킷 업로드/삭제 등을 위한 설정 파일 및 유틸 추가
    - 파일 처리 과정에서 발생하는 예외를 다루기 위한 커스텀 에러 정의
- **`UserController`, `UserService` 분리 및 구성**
    - 기존 Auth 로직에 섞여 있던 사용자 관리 기능을 User 도메인으로 이동
    - `/api/user/me` 엔드포인트 구현: 사용자 본인 정보 조회 가능
    - `/api/user/profile-image` 엔드포인트 구현: 프로필 이미지 업로드/변경 가능
- **사용자 정보 저장 구조 개선**
    - localStorage 저장 목적의 `UserProfileResponseDto` 생성
    - `ProfileImageUpdateResponseDto` 추가

---

### 📘 API 명세
- GET `/api/user/me`  
  - 사용자 본인의 id, email, nickname, profileImageUrl을 반환  
- POST `/api/user/profile-image`  
  - 프로필 이미지 파일 업로드  
  - 유효성 검사 후 새로운 이미지 URL을 반환

---

### 🚧 특이사항
**현재 `UserProfileResponseDto`에 이메일 정보가 포함**되어 있고, 프론트엔드는 이를 **localStorage에 저장**하고 있습니다.
localStorage는 브라우저 내에서 스크립트를 통해 접근이 가능한 영역이라 **XSS 공격에 취약**합니다.
이메일과 같은 개인정보는 **향후 재정비 시 제거해야 합니다.**

---

### 📌 정리
- **AWS S3와 연동**했습니다. submodule 리파지터리를 최신화해야 합니다.
- **프로필 이미지 관리 기능을 구현**했습니다.
- **사용자 관리 로직을 독립된 User 도메인으로 구성**했습니다.
    - 사용자 정보 및 프로필 이미지 업데이트 관련 **DTO를 정의**했습니다.

---

### 📅 향후 계획
- **`UserProfileResponseDto`에서 이메일을 제거**합니다.
- **프론트엔드의 localStorage 저장 구조를 재정비**합니다.