### PR TITLE
feat: 친구 프로필 페이지 열람 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/trip/mapper/TripMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/mapper/TripMapper.java
@@ -63,7 +63,7 @@ public interface TripMapper {
     List<TripItem> selectItemsByTripId(Long tripId);
 
     @Select("SELECT " +
-            "ti.id, ti.trip_id, ti.spot_id, ti.day_number, ti.order_index, ti.memo, ti.created_at, " +
+            "ti.id, ti.trip_id, ti.spot_id, ti.day_number, ti.order_index, ti.memo, " +
             "s.id as s_id, s.kakao_place_id as s_kakao_place_id, s.name as s_name, s.address as s_address, s.category as s_category, " +
             "s.lat as s_lat, s.lng as s_lng, s.place_url as s_place_url, s.thumbnail_url as s_thumbnail_url " +
             "FROM trip_item ti " +

--- a/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
@@ -32,6 +32,7 @@ public class TripService {
                 .visibility(TripVisibility.PRIVATE) // 기본 공개 여부
                 .build();
         tripMapper.insert(newTrip);
+        newTrip.setTripItems(new java.util.ArrayList<>()); // Initialize tripItems to prevent NPE
         return newTrip;
     }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.ssafy.jjtrip.common.s3.exception.FileErrorCode;
 import com.ssafy.jjtrip.common.s3.exception.FileException;
 import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.domain.user.dto.request.UpdateUserRequestDto;
+import com.ssafy.jjtrip.domain.user.dto.response.PublicUserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.ProfileImageUpdateResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.UserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.service.UserService;
@@ -29,8 +30,8 @@ public class UserController {
     }
     
     @GetMapping("/{userId}/profile")
-    public ResponseEntity<UserProfileResponseDto> getUserProfile(@PathVariable("userId") Long userId) {
-        UserProfileResponseDto user = userService.getUserProfile(userId);
+    public ResponseEntity<PublicUserProfileResponseDto> getUserProfile(@PathVariable("userId") Long userId) {
+        PublicUserProfileResponseDto user = userService.getPublicUserProfile(userId);
         return ResponseEntity.ok(user);
     }
 
@@ -40,9 +41,9 @@ public class UserController {
         return ResponseEntity.ok().build();
     }
     
-    @GetMapping("/me/friends")
-    public ResponseEntity<List<UserProfileResponseDto>> getMyFriends(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<UserProfileResponseDto> friends = userService.getFriendsList(userDetails.getUser().getId());
+    @GetMapping("/{userId}/friends")
+    public ResponseEntity<List<PublicUserProfileResponseDto>> getUserFriends(@PathVariable("userId") Long userId) {
+        List<PublicUserProfileResponseDto> friends = userService.getFriendsList(userId);
         return ResponseEntity.ok(friends);
     }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/PublicUserProfileResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/PublicUserProfileResponseDto.java
@@ -2,14 +2,14 @@ package com.ssafy.jjtrip.domain.user.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter; // Added for deserialization if needed in some contexts
+import lombok.Setter;
 
 @Getter
 @Setter
 @Builder
-public class UserProfileResponseDto {
+public class PublicUserProfileResponseDto {
     private Long id;
-    private String email;
+    // No email
     private String nickname;
     private String profileImageUrl;
     private String bio;
@@ -19,12 +19,11 @@ public class UserProfileResponseDto {
     private Long travelStyleId;
     private String profileBannerUrl;
     private Boolean isProfilePublic;
-    private int friendsCount; // Added friendsCount
+    private int friendsCount;
 
-    public static UserProfileResponseDto from(UserAndProfileDto userAndProfile) {
-        return UserProfileResponseDto.builder()
+    public static PublicUserProfileResponseDto from(UserAndProfileDto userAndProfile) {
+        return PublicUserProfileResponseDto.builder()
                 .id(userAndProfile.getId())
-                .email(userAndProfile.getEmail())
                 .nickname(userAndProfile.getNickname())
                 .profileImageUrl(userAndProfile.getProfileImageUrl())
                 .bio(userAndProfile.getBio())
@@ -34,7 +33,7 @@ public class UserProfileResponseDto {
                 .travelStyleId(userAndProfile.getTravelStyleId())
                 .profileBannerUrl(userAndProfile.getProfileBannerUrl())
                 .isProfilePublic(userAndProfile.getIsProfilePublic())
-                .friendsCount(userAndProfile.getFriendsCount()) // Map friendsCount
+                .friendsCount(userAndProfile.getFriendsCount())
                 .build();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserAndProfileDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserAndProfileDto.java
@@ -26,4 +26,5 @@ public class UserAndProfileDto {
     private Long travelStyleId;
     private String profileBannerUrl;
     private Boolean isProfilePublic;
+    private int friendsCount;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
@@ -82,7 +82,7 @@ public interface UserMapper {
 
     @Select("SELECT " +
             "u.id, u.role_id, u.status_id, u.email, u.nickname, u.profile_image_url, " +
-            "up.bio, up.intro, up.home_region_id, up.travel_style_summary, up.travel_style_id, up.profile_banner_url, up.is_profile_public " +
+            "up.bio, up.intro, up.home_region_id, up.travel_style_summary, up.travel_style_id, up.profile_banner_url, up.is_profile_public, up.friends_count " +
             "FROM user u " +
             "LEFT JOIN user_profile up ON u.id = up.user_id " +
             "WHERE u.id = #{userId}")
@@ -99,13 +99,14 @@ public interface UserMapper {
             @Result(property = "travelStyleSummary", column = "travel_style_summary"),
             @Result(property = "travelStyleId", column = "travel_style_id"),
             @Result(property = "profileBannerUrl", column = "profile_banner_url"),
-            @Result(property = "isProfilePublic", column = "is_profile_public")
+            @Result(property = "isProfilePublic", column = "is_profile_public"),
+            @Result(property = "friendsCount", column = "friends_count")
     })
     Optional<UserAndProfileDto> findUserAndProfileById(@Param("userId") Long userId);
 
     @Select("SELECT " +
             "f.id, f.role_id, f.status_id, f.email, f.nickname, f.profile_image_url, " +
-            "fp.bio, fp.intro, fp.home_region_id, fp.travel_style_summary, fp.travel_style_id, fp.profile_banner_url, fp.is_profile_public " +
+            "fp.bio, fp.intro, fp.home_region_id, fp.travel_style_summary, fp.travel_style_id, fp.profile_banner_url, fp.is_profile_public, fp.friends_count " +
             "FROM friendship fs " +
             "JOIN user f ON (fs.user_id_a = f.id OR fs.user_id_b = f.id) AND f.id != #{userId} " +
             "LEFT JOIN user_profile fp ON f.id = fp.user_id " +
@@ -123,7 +124,8 @@ public interface UserMapper {
             @Result(property = "travelStyleSummary", column = "travel_style_summary"),
             @Result(property = "travelStyleId", column = "travel_style_id"),
             @Result(property = "profileBannerUrl", column = "profile_banner_url"),
-            @Result(property = "isProfilePublic", column = "is_profile_public")
+            @Result(property = "isProfilePublic", column = "is_profile_public"),
+            @Result(property = "friendsCount", column = "friends_count")
     })
     List<UserAndProfileDto> findFriendsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.ssafy.jjtrip.common.util.EmailMasker;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.auth.exception.AuthException;
 import com.ssafy.jjtrip.domain.user.dto.request.UpdateUserRequestDto;
+import com.ssafy.jjtrip.domain.user.dto.response.PublicUserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.UserAndProfileDto;
 import com.ssafy.jjtrip.domain.user.dto.response.UserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.entity.User;
@@ -38,10 +39,17 @@ public class UserService {
         return mapToUserProfileResponseDto(userAndProfile);
     }
     
-    public List<UserProfileResponseDto> getFriendsList(Long userId) {
+    public PublicUserProfileResponseDto getPublicUserProfile(Long userId) {
+        UserAndProfileDto userAndProfile = userMapper.findUserAndProfileById(userId)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
+
+        return PublicUserProfileResponseDto.from(userAndProfile);
+    }
+
+    public List<PublicUserProfileResponseDto> getFriendsList(Long userId) {
         List<UserAndProfileDto> friends = userMapper.findFriendsByUserId(userId);
         return friends.stream()
-                .map(this::mapToUserProfileResponseDto)
+                .map(PublicUserProfileResponseDto::from)
                 .collect(Collectors.toList());
     }
 
@@ -117,6 +125,7 @@ public class UserService {
                 .travelStyleId(userAndProfile.getTravelStyleId())
                 .profileBannerUrl(userAndProfile.getProfileBannerUrl())
                 .isProfilePublic(userAndProfile.getIsProfilePublic())
+                .friendsCount(userAndProfile.getFriendsCount()) // Pass friendsCount
                 .build();
     }
     

--- a/src/main/resources/trit-db-setup.sql
+++ b/src/main/resources/trit-db-setup.sql
@@ -1,18 +1,18 @@
 -- =================================================================
--- 데이터베이스 설정
+-- 데이터베이스 설정 (2차 설계 통합)
 -- =================================================================
 DROP DATABASE IF EXISTS jjtrip_dev;
 CREATE DATABASE jjtrip_dev DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 USE jjtrip_dev;
 
 -- =================================================================
--- 1. 사용자 및 권한
+-- 1. 유저 및 권한 (User & Auth)
 -- =================================================================
 
 -- 역할 (Role)
 CREATE TABLE `role` (
   `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'USER', 'ADMIN'
+  `code` VARCHAR(20) NOT NULL UNIQUE COMMENT "'USER', 'ADMIN'",
   `name` VARCHAR(50) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -20,7 +20,7 @@ CREATE TABLE `role` (
 -- 사용자 상태 (User Status)
 CREATE TABLE `user_status` (
   `id`          BIGINT NOT NULL AUTO_INCREMENT,
-  `code`        VARCHAR(20) NOT NULL UNIQUE, -- 'ACTIVE', 'DELETED'
+  `code`        VARCHAR(20) NOT NULL UNIQUE COMMENT "'ACTIVE', 'DELETED'",
   `name`        VARCHAR(50) NOT NULL,
   `description` VARCHAR(100),
   PRIMARY KEY (`id`)
@@ -31,19 +31,18 @@ CREATE TABLE `user` (
   `id`                BIGINT NOT NULL AUTO_INCREMENT,
   `role_id`           BIGINT NOT NULL,
   `status_id`         BIGINT NOT NULL,
-  `email`             VARCHAR(100) NOT NULL UNIQUE,
-  `password_hash`     VARCHAR(255) NOT NULL,
-  `nickname`          VARCHAR(50) NOT NULL,
+  `email`             VARCHAR(100) UNIQUE,
+  `password_hash`     VARCHAR(255),
+  `nickname`          VARCHAR(50),
   `profile_image_url` VARCHAR(255),
-  `created_at`        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `created_at`        DATETIME DEFAULT NOW(),
+  `updated_at`        DATETIME,
   PRIMARY KEY (`id`),
-  KEY `idx_user_email` (`email`),
   CONSTRAINT `fk_user_role` FOREIGN KEY (`role_id`) REFERENCES `role` (`id`),
   CONSTRAINT `fk_user_status` FOREIGN KEY (`status_id`) REFERENCES `user_status` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 사용자 프로필 (User Profile)
+-- 사용자 프로필 (User Profile) - 기존 테이블 유지
 CREATE TABLE `user_profile` (
   `user_id`                 BIGINT NOT NULL,
   `bio`                     VARCHAR(255),
@@ -53,13 +52,14 @@ CREATE TABLE `user_profile` (
   `travel_style_id`         BIGINT,
   `profile_banner_url`      VARCHAR(255),
   `is_profile_public`       BOOLEAN NOT NULL DEFAULT TRUE,
+  `friends_count`           INT NOT NULL DEFAULT 0, -- Added friends_count column
   `created_at`              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`user_id`),
   CONSTRAINT `fk_user_profile_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 친구 관계 (Friendship)
+-- 친구 관계 (Friendship) - 기존 테이블 유지
 CREATE TABLE `friendship` (
   `user_id_a`  BIGINT NOT NULL,
   `user_id_b`  BIGINT NOT NULL,
@@ -71,18 +71,132 @@ CREATE TABLE `friendship` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- =================================================================
--- 2. 지역
+-- 2. 장소 (Spot) - 2차 설계 반영
 -- =================================================================
 
--- 지역 유형 (Region Type)
+CREATE TABLE `spot` (
+  `id`             BIGINT NOT NULL AUTO_INCREMENT,
+  `kakao_place_id` VARCHAR(50) UNIQUE NOT NULL COMMENT "카카오맵 고유 ID",
+  `name`           VARCHAR(100) NOT NULL,
+  `address`        VARCHAR(255),
+  `category`       VARCHAR(50),
+  `lat`            DECIMAL(10,8) NOT NULL,
+  `lng`            DECIMAL(11,8) NOT NULL,
+  `place_url`      VARCHAR(255),
+  `thumbnail_url`  VARCHAR(255),
+  `review_count`   INT DEFAULT 0,
+  `average_rating` DECIMAL(3,2) DEFAULT 0,
+  `created_at`     DATETIME DEFAULT NOW(),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- =================================================================
+-- 3. 여행 계획 (Trip Plan) - 2차 설계 반영
+-- =================================================================
+
+-- 여행 상태 마스터
+CREATE TABLE `trip_status` (
+  `id`          BIGINT NOT NULL AUTO_INCREMENT,
+  `code`        VARCHAR(20) UNIQUE NOT NULL COMMENT "'DRAFT', 'PLANNED', 'COMPLETED'",
+  `name`        VARCHAR(50) NOT NULL COMMENT "작성 중, 계획 완료, 여행 완료",
+  `description` VARCHAR(100),
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 여행 계획
+CREATE TABLE `trip` (
+  `id`             BIGINT NOT NULL AUTO_INCREMENT,
+  `user_id`        BIGINT NOT NULL,
+  `trip_status_id` BIGINT NOT NULL,
+  `title`          VARCHAR(100) NOT NULL,
+  `start_date`     DATE,
+  `end_date`       DATE,
+  `visibility`     VARCHAR(20) NOT NULL DEFAULT 'PRIVATE' COMMENT "'PUBLIC' 또는 'PRIVATE'",
+  `created_at`     DATETIME DEFAULT NOW(),
+  `updated_at`     DATETIME,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_trip_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_trip_status` FOREIGN KEY (`trip_status_id`) REFERENCES `trip_status` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 여행 계획 아이템
+CREATE TABLE `trip_item` (
+  `id`          BIGINT NOT NULL AUTO_INCREMENT,
+  `trip_id`     BIGINT NOT NULL,
+  `spot_id`     BIGINT NOT NULL,
+  `day_number`  INT NOT NULL COMMENT "1일차, 2일차...",
+  `order_index` INT NOT NULL COMMENT "방문 순서",
+  `memo`        TEXT,
+  `created_at`  DATETIME DEFAULT NOW(), -- Added created_at column
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_trip_item_trip` FOREIGN KEY (`trip_id`) REFERENCES `trip` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_trip_item_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+
+-- =================================================================
+-- 4. 여행 로그 (Trip Log) - [신규]
+-- =================================================================
+
+CREATE TABLE `trip_log` (
+  `id`               BIGINT NOT NULL AUTO_INCREMENT,
+  `user_id`          BIGINT NOT NULL,
+  `original_trip_id` BIGINT COMMENT "어떤 여행 계획을 바탕으로 작성되었는지 (선택)",
+  `title`            VARCHAR(100) NOT NULL,
+  `content`          TEXT NOT NULL,
+  `visibility`       VARCHAR(20) NOT NULL DEFAULT 'PRIVATE' COMMENT "'PUBLIC' 또는 'PRIVATE'",
+  `created_at`       DATETIME DEFAULT NOW(),
+  `updated_at`       DATETIME,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_trip_log_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_trip_log_original_trip` FOREIGN KEY (`original_trip_id`) REFERENCES `trip` (`id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- =================================================================
+-- 5. 리뷰 (Review) - [신규]
+-- =================================================================
+
+CREATE TABLE `review` (
+  `id`        BIGINT NOT NULL AUTO_INCREMENT,
+  `spot_id`   BIGINT NOT NULL,
+  `user_id`   BIGINT NOT NULL,
+  `content`   TEXT NOT NULL,
+  `rating`    INT NOT NULL COMMENT "1 ~ 5 점",
+  `image_url` VARCHAR(255),
+  `created_at` DATETIME DEFAULT NOW(),
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_review_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_review_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- =================================================================
+-- 6. 스크랩 (Scrap) - [신규]
+-- =================================================================
+
+CREATE TABLE `scrap` (
+  `id`              BIGINT NOT NULL AUTO_INCREMENT,
+  `user_id`         BIGINT NOT NULL COMMENT "스크랩한 유저",
+  `scrappable_id`   BIGINT NOT NULL COMMENT "스크랩된 대상의 ID (spot.id, trip.id, trip_log.id 등)",
+  `scrappable_type` VARCHAR(50) NOT NULL COMMENT "스크랩된 대상의 타입 ('SPOT', 'TRIP', 'TRIP_LOG')",
+  `created_at`      DATETIME DEFAULT NOW(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_scrap` (`user_id`, `scrappable_id`, `scrappable_type`),
+  CONSTRAINT `fk_scrap_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- =================================================================
+-- 7. 기존 테이블 유지 (채팅, 저널 등)
+-- =================================================================
+
+-- 지역 유형 (Region Type) - 기존 테이블 유지
 CREATE TABLE `region_type` (
   `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'CITY', 'DISTRICT'
+  `code` VARCHAR(20) NOT NULL UNIQUE,
   `name` VARCHAR(50) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 지역 (Region)
+-- 지역 (Region) - 기존 테이블 유지
 CREATE TABLE `region` (
   `id`           BIGINT NOT NULL AUTO_INCREMENT,
   `parent_id`    BIGINT,
@@ -98,121 +212,15 @@ CREATE TABLE `region` (
   CONSTRAINT `fk_region_type` FOREIGN KEY (`type_id`) REFERENCES `region_type` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 지역 경계 (Region Boundary)
-CREATE TABLE `region_boundary` (
-  `region_id`        BIGINT NOT NULL,
-  `boundary_geojson` TEXT NOT NULL,
-  `created_at`       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`region_id`),
-  CONSTRAINT `fk_region_boundary_region` FOREIGN KEY (`region_id`) REFERENCES `region` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- =================================================================
--- 3. 장소 관련
--- =================================================================
-
--- 장소 상태 (Spot Status)
-CREATE TABLE `spot_status` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'ACTIVE', 'CLOSED'
-  `name` VARCHAR(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 카테고리 (Spot Category)
-CREATE TABLE `spot_category` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `name` VARCHAR(100) NOT NULL UNIQUE,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 (Spot)
-CREATE TABLE `spot` (
-  `id`                BIGINT NOT NULL AUTO_INCREMENT,
-  `region_id`         BIGINT NOT NULL,
-  `category_id`       BIGINT NOT NULL,
-  `status_id`         BIGINT NOT NULL,
-  `name`              VARCHAR(255) NOT NULL,
-  `lat`               DOUBLE NOT NULL,
-  `lon`               DOUBLE NOT NULL,
-  `summary`           TEXT,
-  `address`           TEXT,
-  `phone`             VARCHAR(50),
-  `primary_photo_url` TEXT,
-  `source_provider`   VARCHAR(50),
-  `source_place_id`   VARCHAR(100),
-  `created_at`        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_source_place` (`source_provider`, `source_place_id`),
-  KEY `idx_lat_lon` (`lat`, `lon`),
-  CONSTRAINT `fk_spot_region` FOREIGN KEY (`region_id`) REFERENCES `region` (`id`),
-  CONSTRAINT `fk_spot_category` FOREIGN KEY (`category_id`) REFERENCES `spot_category` (`id`),
-  CONSTRAINT `fk_spot_status` FOREIGN KEY (`status_id`) REFERENCES `spot_status` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 카테고리 맵 (Spot Category Map)
-CREATE TABLE `spot_category_map` (
-  `spot_id`     BIGINT NOT NULL,
-  `category_id` BIGINT NOT NULL,
-  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`spot_id`, `category_id`),
-  CONSTRAINT `fk_spot_cat_map_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_spot_cat_map_category` FOREIGN KEY (`category_id`) REFERENCES `spot_category` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 사진 (Spot Photo)
-CREATE TABLE `spot_photo` (
-  `id`         BIGINT NOT NULL AUTO_INCREMENT,
-  `spot_id`    BIGINT NOT NULL,
-  `url`        TEXT NOT NULL,
-  `is_primary` BOOLEAN NOT NULL DEFAULT FALSE,
-  `width`      INT,
-  `height`     INT,
-  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_spot_photo_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 영업시간 (Spot Hour)
-CREATE TABLE `spot_hour` (
-  `id`          BIGINT NOT NULL AUTO_INCREMENT,
-  `spot_id`     BIGINT NOT NULL,
-  `dow`         SMALLINT NOT NULL, -- 요일 (0=일, 1=월, ..., 6=토)
-  `segment_no`  SMALLINT NOT NULL DEFAULT 1,
-  `is_24h`      BOOLEAN NOT NULL DEFAULT FALSE,
-  `open_time`   TIME,
-  `close_time`  TIME,
-  `break_start` TIME,
-  `break_end`   TIME,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_spot_hour_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 장소 영업시간 예외 (Spot Hour Exception)
-CREATE TABLE `spot_hour_exception` (
-  `id`         BIGINT NOT NULL AUTO_INCREMENT,
-  `spot_id`    BIGINT NOT NULL,
-  `date`       DATE NOT NULL,
-  `is_closed`  BOOLEAN NOT NULL DEFAULT FALSE,
-  `open_time`  TIME,
-  `close_time` TIME,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_spot_hour_exception_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- =================================================================
--- 4. 태그
--- =================================================================
-
--- 태그 카테고리 (Tag Category)
+-- 태그 카테고리 (Tag Category) - 기존 테이블 유지
 CREATE TABLE `tag_category` (
   `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'THEME', 'MOOD'
+  `code` VARCHAR(20) NOT NULL UNIQUE,
   `name` VARCHAR(50) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 태그 (Tag)
+-- 태그 (Tag) - 기존 테이블 유지
 CREATE TABLE `tag` (
   `id`          BIGINT NOT NULL AUTO_INCREMENT,
   `name`        VARCHAR(50) NOT NULL UNIQUE,
@@ -222,333 +230,78 @@ CREATE TABLE `tag` (
   CONSTRAINT `fk_tag_category` FOREIGN KEY (`category_id`) REFERENCES `tag_category` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 장소 태그 (Spot Tag)
-CREATE TABLE `spot_tag` (
-  `spot_id` BIGINT NOT NULL,
-  `tag_id`  BIGINT NOT NULL,
-  PRIMARY KEY (`spot_id`, `tag_id`),
-  CONSTRAINT `fk_spot_tag_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_spot_tag_tag` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- =================================================================
--- 5. 여행 계획
--- =================================================================
-
--- 여행 상태 (Trip Status)
-CREATE TABLE `trip_status` (
-  `id`          BIGINT NOT NULL AUTO_INCREMENT,
-  `code`        VARCHAR(20) NOT NULL UNIQUE, -- 'DRAFT', 'PLANNED', 'COMPLETED'
-  `name`        VARCHAR(50) NOT NULL,
-  `description` VARCHAR(100),
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 계획 상태 (Plan Status)
-CREATE TABLE `plan_status` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'PLANNED', 'DONE'
-  `name` VARCHAR(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 계획 (Travel Plan)
-CREATE TABLE `travel_plan` (
-  `id`            BIGINT NOT NULL AUTO_INCREMENT,
-  `user_id`       BIGINT NOT NULL,
-  `status_id`     BIGINT NOT NULL,
-  `title`         VARCHAR(100) NOT NULL,
-  `summary`       VARCHAR(255),
-  `planned_date`  DATE,
-  `visited_date`  DATE,
-  `region_code`   VARCHAR(50),
-  `area_name`     VARCHAR(100),
-  `thumbnail_url` VARCHAR(255),
-  `is_public`     BOOLEAN NOT NULL DEFAULT TRUE,
-  `is_deleted`    BOOLEAN NOT NULL DEFAULT FALSE,
-  `created_at`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_travel_plan_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_plan_status` FOREIGN KEY (`status_id`) REFERENCES `plan_status` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 계획 아이템 (Travel Plan Item)
-CREATE TABLE `travel_plan_item` (
-  `id`         BIGINT NOT NULL AUTO_INCREMENT,
-  `plan_id`    BIGINT NOT NULL,
-  `spot_id`    BIGINT NOT NULL,
-  `order_no`   INT NOT NULL,
-  `memo`       TEXT,
-  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_plan_order` (`plan_id`, `order_no`),
-  CONSTRAINT `fk_travel_plan_item_plan` FOREIGN KEY (`plan_id`) REFERENCES `travel_plan` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_plan_item_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 계획 태그 (Travel Plan Tag)
-CREATE TABLE `travel_plan_tag` (
-  `plan_id` BIGINT NOT NULL,
-  `tag_id`  BIGINT NOT NULL,
-  PRIMARY KEY (`plan_id`, `tag_id`),
-  CONSTRAINT `fk_travel_plan_tag_plan` FOREIGN KEY (`plan_id`) REFERENCES `travel_plan` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_plan_tag_tag` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- =================================================================
--- 6. 채팅
--- =================================================================
-
--- 채팅방 유형 (Chat Room Type)
+-- 채팅방 유형 (Chat Room Type) - 기존 테이블 유지
 CREATE TABLE `chat_room_type` (
   `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'PLAN', 'DM'
+  `code` VARCHAR(20) NOT NULL UNIQUE,
   `name` VARCHAR(50) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 채팅방 (Chat Room)
+-- 채팅방 (Chat Room) - 기존 테이블 유지
 CREATE TABLE `chat_room` (
   `id`         BIGINT NOT NULL AUTO_INCREMENT,
-  `plan_id`    BIGINT,
-  `type_id`    BIGINT NOT NULL,
   `name`       VARCHAR(100),
   `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_chat_room_plan` FOREIGN KEY (`plan_id`) REFERENCES `travel_plan` (`id`) ON DELETE SET NULL,
-  CONSTRAINT `fk_chat_room_type` FOREIGN KEY (`type_id`) REFERENCES `chat_room_type` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 채팅방 멤버 (Chat Room Member)
-CREATE TABLE `chat_room_member` (
-  `room_id`   BIGINT NOT NULL,
-  `user_id`   BIGINT NOT NULL,
-  `joined_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_active` BOOLEAN NOT NULL DEFAULT TRUE,
-  PRIMARY KEY (`room_id`, `user_id`),
-  CONSTRAINT `fk_chat_room_member_room` FOREIGN KEY (`room_id`) REFERENCES `chat_room` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_chat_room_member_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 채팅 메시지 유형 (Chat Message Type)
-CREATE TABLE `chat_message_type` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'TEXT', 'IMAGE'
-  `name` VARCHAR(50) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 채팅 메시지 (Chat Message)
-CREATE TABLE `chat_message` (
-  `id`              BIGINT NOT NULL AUTO_INCREMENT,
-  `room_id`         BIGINT NOT NULL,
-  `sender_id`       BIGINT NOT NULL,
-  `message_type_id` BIGINT NOT NULL,
-  `content`         TEXT,
-  `file_url`        VARCHAR(500),
-  `created_at`      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_deleted`      BOOLEAN NOT NULL DEFAULT FALSE,
-  PRIMARY KEY (`id`),
-  KEY `idx_chat_message_room_created_at` (`room_id`, `created_at`),
-  CONSTRAINT `fk_chat_message_room` FOREIGN KEY (`room_id`) REFERENCES `chat_room` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_chat_message_sender` FOREIGN KEY (`sender_id`) REFERENCES `user` (`id`),
-  CONSTRAINT `fk_chat_message_type` FOREIGN KEY (`message_type_id`) REFERENCES `chat_message_type` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- =================================================================
--- 7. 북마크, 일지, 프로필
--- =================================================================
-
--- 여행 계획 북마크 (Travel Plan Bookmark)
-CREATE TABLE `travel_plan_bookmark` (
-  `user_id`    BIGINT NOT NULL,
-  `plan_id`    BIGINT NOT NULL,
-  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`user_id`, `plan_id`),
-  CONSTRAINT `fk_travel_plan_bookmark_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_plan_bookmark_plan` FOREIGN KEY (`plan_id`) REFERENCES `travel_plan` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 일지 분위기 (Travel Journal Mood)
-CREATE TABLE `travel_journal_mood` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'HAPPY', 'TIRED'
-  `name` VARCHAR(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 일지 (Travel Journal)
+-- 여행 저널 (Travel Journal) - 기존 테이블 유지. FK는 나중에 수동으로 연결해야 할 수 있음.
 CREATE TABLE `travel_journal` (
   `id`           BIGINT NOT NULL AUTO_INCREMENT,
-  `plan_id`      BIGINT NOT NULL,
   `user_id`      BIGINT NOT NULL,
-  `visited_date` DATE NOT NULL,
   `title`        VARCHAR(120) NOT NULL,
   `diary`        TEXT,
-  `mood_id`      BIGINT,
-  `weather_note` VARCHAR(50),
-  `companion`    VARCHAR(100),
-  `rating`       TINYINT,
-  `total_spent`  INT,
   `is_private`   BOOLEAN NOT NULL DEFAULT FALSE,
   `is_deleted`   BOOLEAN NOT NULL DEFAULT FALSE,
   `created_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  CONSTRAINT `fk_travel_journal_plan` FOREIGN KEY (`plan_id`) REFERENCES `travel_plan` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_journal_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_journal_mood` FOREIGN KEY (`mood_id`) REFERENCES `travel_journal_mood` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 일지 사진 (Travel Journal Photo)
-CREATE TABLE `travel_journal_photo` (
-  `id`         BIGINT NOT NULL AUTO_INCREMENT,
-  `journal_id` BIGINT NOT NULL,
-  `spot_id`    BIGINT,
-  `url`        TEXT NOT NULL,
-  `taken_at`   DATETIME,
-  `caption`    TEXT,
-  `order_no`   INT,
-  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`),
-  CONSTRAINT `fk_travel_journal_photo_journal` FOREIGN KEY (`journal_id`) REFERENCES `travel_journal` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_travel_journal_photo_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 여행 스타일 (Travel Style)
-CREATE TABLE `travel_style` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'CAFE_LOVER'
-  `name` VARCHAR(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 배지 (Badge)
-CREATE TABLE `badge` (
-  `id`          BIGINT NOT NULL AUTO_INCREMENT,
-  `code`        VARCHAR(50) NOT NULL UNIQUE,
-  `name`        VARCHAR(100) NOT NULL,
-  `description` VARCHAR(255),
-  `icon_url`    VARCHAR(255),
-  `category`    VARCHAR(30),
-  `level`       INT,
-  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 사용자 배지 (User Badge)
-CREATE TABLE `user_badge` (
-  `user_id`     BIGINT NOT NULL,
-  `badge_id`    BIGINT NOT NULL,
-  `obtained_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_pinned`   BOOLEAN NOT NULL DEFAULT FALSE,
-  PRIMARY KEY (`user_id`, `badge_id`),
-  CONSTRAINT `fk_user_badge_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_user_badge_badge` FOREIGN KEY (`badge_id`) REFERENCES `badge` (`id`) ON DELETE CASCADE
+  CONSTRAINT `fk_travel_journal_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 -- =================================================================
--- 8. 시드 데이터 (초기 데이터)
+-- 8. 시드 데이터 (Seed Data)
 -- =================================================================
 
 -- 기본 역할
-INSERT INTO `role` (id, code, name) VALUES
-(1, 'USER',  '일반 사용자'),
-(2, 'ADMIN', '관리자');
+INSERT INTO `role` (id, code, name) VALUES (1, 'USER', '일반 사용자'), (2, 'ADMIN', '관리자');
 
 -- 기본 사용자 상태
-INSERT INTO `user_status` (id, code, name, description) VALUES
-(1, 'ACTIVE',  '활성', '일반 활성 사용자'),
-(2, 'DELETED', '탈퇴', '탈퇴 또는 비활성 사용자');
+INSERT INTO `user_status` (id, code, name, description) VALUES (1, 'ACTIVE', '활성', '일반 활성 사용자'), (2, 'DELETED', '탈퇴', '탈퇴 또는 비활성 사용자');
 
--- 기본 여행 상태
-INSERT INTO `trip_status` (id, code, name, description) VALUES
-(1, 'DRAFT',     '작성중', '작성중인 여행 계획'),
-(2, 'PLANNED',   '계획완료', '여행 계획이 완료된 상태'),
-(3, 'COMPLETED', '여행완료', '실제로 여행이 완료된 상태');
-
--- 지역 유형
-INSERT INTO `region_type` (id, code, name) VALUES
-(1, 'CITY', '시'),
-(2, 'PROVINCE', '도');
-
--- 지역 (최소 데이터)
-INSERT INTO `region` (id, type_id, name, slug) VALUES
-(1, 1, '서울', 'seoul'),
-(2, 1, '부산', 'busan'),
-(3, 1, '제주', 'jeju');
-
--- 장소 상태
-INSERT INTO `spot_status` (id, code, name) VALUES
-(1, 'ACTIVE', '운영중'),
-(2, 'CLOSED', '폐업');
-
--- 장소 카테고리
-INSERT INTO `spot_category` (id, name) VALUES
-(1, '카페'),
-(2, '관광지'),
-(3, '레스토랑');
-
--- 태그 카테고리
-INSERT INTO `tag_category` (id, code, name) VALUES
-(1, 'THEME', '테마'),
-(2, 'MOOD', '분위기');
-
--- 태그 (최소 데이터)
-INSERT INTO `tag` (id, name, category_id) VALUES
-(1, '힐링', 1),
-(2, '액티비티', 1),
-(3, '혼자여행', 1),
-(4, '커플여행', 1),
-(5, '가족여행', 1);
-
--- 계획 상태
-INSERT INTO `plan_status` (id, code, name) VALUES
-(1, 'PLANNED', '계획됨'),
-(2, 'DONE', '완료');
-
--- 채팅방 유형
-INSERT INTO `chat_room_type` (id, code, name) VALUES
-(1, 'PLAN', '계획'),
-(2, 'DM', '다이렉트 메시지');
-
--- 채팅 메시지 유형
-INSERT INTO `chat_message_type` (id, code, name) VALUES
-(1, 'TEXT', '텍스트'),
-(2, 'IMAGE', '이미지');
-
--- 여행 일지 분위기
-INSERT INTO `travel_journal_mood` (id, code, name) VALUES
-(1, 'HAPPY', '행복함'),
-(2, 'TIRED', '피곤함'),
-(3, 'EXCITED', '신남'),
-(4, 'RELAXED', '편안함');
-
--- 여행 스타일 (최소 데이터)
-INSERT INTO `travel_style` (id, code, name) VALUES
-(1, 'CAFE_HOPPER', '카페 탐방가'),
-(2, 'ADVENTURER', '모험가'),
-(3, 'FOODIE', '미식가');
-
--- 배지 (최소 데이터)
-INSERT INTO `badge` (id, code, name, description, icon_url, category, level) VALUES
-(1, 'FIRST_TRIP', '첫 여행', '첫 여행 계획 완료', NULL, 'TRIP', 1),
-(2, 'PHOTO_MASTER', '사진 장인', '사진 100장 업로드', NULL, 'PHOTO', 2);
+-- 여행 상태 마스터
+INSERT INTO `trip_status` (id, code, name, description) VALUES (1, 'DRAFT', '작성중', '작성중인 여행 계획'), (2, 'PLANNED', '계획완료', '여행 계획이 완료된 상태'), (3, 'COMPLETED', '여행완료', '실제로 여행이 완료된 상태');
 
 -- 더미 사용자 (사용자 제공 계정)
-INSERT INTO `user` (id, role_id, status_id, email, password_hash, nickname, profile_image_url) VALUES
-(1, 1, 1, 'hi@hi.hi', '$2a$10$uyMhCnceQ3ORnCNk.wvfOeZt3EqtJNKzlD0OYZ.veOJYa2SgPFszu', '테스트 계정1', NULL),
-(2, 1, 1, 'hi1@hi.hi', '$2a$10$uB2MdvuEvR460eGyC/H8w.j3ghCsBzLFRN7FOXpbG0vjCTx6o9n2K', '테스트 계정2', NULL),
-(3, 1, 1, 'hi2@hi.hi', '$2a$10$1cA1Jc5KIeCCfBGAPKBbH.pt5dDiSKTgRX/j8aixQa1Pk8xB2Dreq', '테스트 계정3', NULL);
+INSERT INTO `user` (id, role_id, status_id, email, password_hash, nickname) VALUES
+(1, 1, 1, 'hi@hi.hi', '$2a$10$uyMhCnceQ3ORnCNk.wvfOeZt3EqtJNKzlD0OYZ.veOJYa2SgPFszu', '테스트 계정1'),
+(2, 1, 1, 'hi1@hi.hi', '$2a$10$uB2MdvuEvR460eGyC/H8w.j3ghCsBzLFRN7FOXpbG0vjCTx6o9n2K', '테스트 계정2'),
+(3, 1, 1, 'hi2@hi.hi', '$2a$10$1cA1Jc5KIeCCfBGAPKBbH.pt5dDiSKTgRX/j8aixQa1Pk8xB2Dreq', '테스트 계정3');
 
 -- 더미 사용자 프로필 (사용자 제공 계정)
-INSERT INTO `user_profile` (user_id, bio, intro, home_region_id, travel_style_summary, travel_style_id, profile_banner_url, is_profile_public) VALUES
-(1, '안녕하세요! 테스트 계정1입니다.', NULL, NULL, NULL, NULL, NULL, TRUE),
-(2, '안녕하세요! 테스트 계정2입니다.', NULL, NULL, NULL, NULL, NULL, TRUE),
-(3, '안녕하세요! 테스트 계정3입니다.', NULL, NULL, NULL, NULL, NULL, TRUE);
+INSERT INTO `user_profile` (user_id, bio, intro, friends_count) VALUES
+(1, '안녕하세요! 테스트 계정1입니다.', '테스트 계정 1의 자기소개', 2),
+(2, '안녕하세요! 테스트 계정2입니다.', '테스트 계정 2의 자기소개', 2),
+(3, '안녕하세요! 테스트 계정3입니다.', '테스트 계정 3의 자기소개', 2);
 
--- 더미 친구 관계 (제거 - 사용자 수가 3명으로 변경됨)
+-- 더미 친구 관계
+INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (1, 2);
+INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (1, 3);
+INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (2, 3);
+INSERT INTO `spot` (kakao_place_id, name, address, category, lat, lng, place_url) VALUES
+('27392064', '아쿠아플라넷 제주', '제주 서귀포시 성산읍 섭지코지로 95', '테마파크', 33.43041, 126.9242, 'http://place.map.kakao.com/27392064'),
+('8035229', '성산일출봉', '제주 서귀포시 성산읍 성산리 1', '명소', 33.45806, 126.9425, 'http://place.map.kakao.com/8035229'),
+('7948366', '카멜리아힐', '제주 서귀포시 안덕면 병악로 166', '공원', 33.2989, 126.3939, 'http://place.map.kakao.com/7948366');
+
+-- 더미 여행 계획
+INSERT INTO `trip` (user_id, trip_status_id, title, start_date, end_date, visibility) VALUES
+(1, 2, '제주도 2박 3일 여행', '2024-03-10', '2024-03-12', 'PUBLIC');
+
+-- 더미 여행 아이템
+INSERT INTO `trip_item` (trip_id, spot_id, day_number, order_index, memo) VALUES
+(1, 1, 1, 1, '오전 10시 도착 예정'),
+(1, 2, 2, 1, '일출 보러 가기'),
+(1, 3, 2, 2, '점심 먹고 산책');


### PR DESCRIPTION
## Issue
- #23 

## Details
이 PR은 마이 페이지(여행 LOG 페이지) 내에서의 친구 기능을 구현했습니다.
친구 수를 나타내는 텍스트를 클릭하면 해당 사용자의 친구 목록을 모달창으로 볼 수 있습니다.
각 사용자의 닉네임을 클릭하면 해당 사용자의 프로필 페이지로 이동합니다.

### ✔️ 주요 변경 사항
- 타 사용자의 프로필 페이지 열람을 위한 전용 DTO 추가
- 엔드포인트(`/api/user/{userId}/profile`, `/api/user/{userId}/friends` 수정
- 스키마 파일에 친구 관계 설정 코드 추가

---

### 📘 API 명세
- GET `/api/user/{userId}/profile`
  - `userId`를 기반으로 사용자의 프로필 정보를 반환
  - 반환되는 DTO를 email을 제거한 `PublicUserProfileResponseDto`로 변경
    - GET `/api/user/me` 엔드포인트(자기 자신의 프로필 정보)로 접근하면 email이 포함된 `UserProfileResponseDto`가 반환됨
- GET `/api/user/{userId}/friends`
  - `userId`를 기반으로 해당 사용자의 친구 목록을 `List<PublicUserProfileResponseDto>`로 반환

---

### 📌 정리
- 마이 페이지의 친구 탭을 통해서 다른 친구들의 프로필 페이지로 이동할 수 있습니다.