### PR TITLE
feat: 여행 기록 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                                 "/api/auth/reset-password",
                                 "/api/auth/logout"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/trip-logs/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/trip-logs/**", "/api/trips/**").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -60,7 +61,7 @@ public class SecurityConfig {
                                 "/api/auth/reset-password",
                                 "/api/auth/logout"
                         ).permitAll()
-                        .requestMatchers("/api/user/**").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/trip-logs/**").permitAll()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/ssafy/jjtrip/domain/trip/controller/TripController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/controller/TripController.java
@@ -60,7 +60,8 @@ public class TripController {
 
     @GetMapping("/{tripId}")
     public ResponseEntity<?> getTripDetail(@PathVariable Long tripId, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Trip trip = tripService.getTripDetail(tripId, userDetails.getUser().getId());
+        Long userId = (userDetails != null) ? userDetails.getUser().getId() : null;
+        Trip trip = tripService.getTripDetail(tripId, userId);
         TripDetailResponseDto responseDto = TripDetailResponseDto.from(trip);
         return ResponseEntity.ok(responseDto);
     }

--- a/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
@@ -66,7 +66,7 @@ public class TripService {
     public Trip getTripDetail(Long tripId, Long userId) {
         Trip trip = findTripById(tripId);
 
-        if (trip.getVisibility() != TripVisibility.PUBLIC && !trip.getUserId().equals(userId)) {
+        if (trip.getVisibility() != TripVisibility.PUBLIC && (userId == null || !trip.getUserId().equals(userId))) {
             throw new TripException(TripErrorCode.FORBIDDEN_TRIP_ACCESS);
         }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
@@ -1,0 +1,22 @@
+package com.ssafy.jjtrip.domain.triplog.controller;
+
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
+import com.ssafy.jjtrip.domain.triplog.service.TripLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trip-logs")
+public class TripLogController {
+
+    private final TripLogService tripLogService;
+
+    @GetMapping("/{logId}")
+    public TripLogDetailResponseDto getTripLogDetail(@PathVariable Long logId) {
+        return tripLogService.getTripLogDetail(logId);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogCommentResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogCommentResponseDto.java
@@ -1,0 +1,12 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+import java.time.LocalDateTime;
+
+public record TripLogCommentResponseDto(
+        Long commentId,
+        String authorNickname,
+        String authorImageUrl,
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogDetailResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogDetailResponseDto.java
@@ -1,0 +1,54 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TripLogDetailResponseDto(
+        Long logId,
+        String title,
+        String content,
+        String locationSummary,
+        int likeCount,
+        int commentCount,
+        LocalDateTime createdAt,
+        String authorNickname,
+        String authorImageUrl,
+        Long tripId,
+        String tripTitle,
+        List<TripLogImageResponseDto> images,
+        List<TripLogCommentResponseDto> comments
+) {
+    public record BaseInfo(
+            Long logId,
+            String title,
+            String content,
+            String locationSummary,
+            int likeCount,
+            int commentCount,
+            LocalDateTime createdAt,
+            String authorNickname,
+            String authorImageUrl,
+            Long tripId,
+            String tripTitle
+    ) {}
+
+    public static TripLogDetailResponseDto from(
+            BaseInfo baseInfo, List<TripLogImageResponseDto> images, List<TripLogCommentResponseDto> comments
+    ) {
+        return new TripLogDetailResponseDto(
+                baseInfo.logId(),
+                baseInfo.title(),
+                baseInfo.content(),
+                baseInfo.locationSummary(),
+                baseInfo.likeCount(),
+                baseInfo.commentCount(),
+                baseInfo.createdAt(),
+                baseInfo.authorNickname(),
+                baseInfo.authorImageUrl(),
+                baseInfo.tripId(),
+                baseInfo.tripTitle(),
+                images,
+                comments
+        );
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogImageResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogImageResponseDto.java
@@ -1,0 +1,8 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+public record TripLogImageResponseDto(
+        String imageRefKey,
+        String imageUrl,
+        int orderIndex
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLog.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLog.java
@@ -1,0 +1,28 @@
+package com.ssafy.jjtrip.domain.triplog.entity;
+
+import com.ssafy.jjtrip.common.entity.BaseEntityWithUpdate;
+import com.ssafy.jjtrip.domain.trip.entity.Trip;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class TripLog extends BaseEntityWithUpdate {
+
+    private Long tripId;
+    private String title;
+    private String content;
+    private String locationSummary;
+    private Integer likeCount;
+    private Integer commentCount;
+
+    private Trip trip;
+    private List<TripLogImage> images;
+    private List<TripLogComment> comments;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogComment.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogComment.java
@@ -1,0 +1,21 @@
+package com.ssafy.jjtrip.domain.triplog.entity;
+
+import com.ssafy.jjtrip.common.entity.BaseEntityWithUpdate;
+import com.ssafy.jjtrip.domain.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class TripLogComment extends BaseEntityWithUpdate {
+
+    private Long logId;
+    private Long userId;
+    private String content;
+
+    private User user;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogImage.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogImage.java
@@ -1,0 +1,20 @@
+package com.ssafy.jjtrip.domain.triplog.entity;
+
+import com.ssafy.jjtrip.common.entity.BaseEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class TripLogImage extends BaseEntity {
+
+    private Long logId;
+    private Long userId;
+    private String imageUrl;
+    private Integer orderIndex;
+    private String imageRefKey;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogLike.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLogLike.java
@@ -1,0 +1,19 @@
+package com.ssafy.jjtrip.domain.triplog.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TripLogLike {
+
+    private Long userId;
+    private Long logId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/exception/TripLogErrorCode.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/exception/TripLogErrorCode.java
@@ -1,0 +1,17 @@
+package com.ssafy.jjtrip.domain.triplog.exception;
+
+import com.ssafy.jjtrip.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TripLogErrorCode implements ErrorCode {
+
+    LOG_NOT_FOUND("TRIPLOG_001", "해당 여행 기록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/exception/TripLogException.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/exception/TripLogException.java
@@ -1,0 +1,10 @@
+package com.ssafy.jjtrip.domain.triplog.exception;
+
+import com.ssafy.jjtrip.common.exception.BusinessException;
+
+public class TripLogException extends BusinessException {
+
+    public TripLogException(TripLogErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -1,0 +1,82 @@
+package com.ssafy.jjtrip.domain.triplog.mapper;
+
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Select;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface TripLogMapper {
+
+    @Select("SELECT " +
+            "tl.id as logId, " +
+            "tl.title, " +
+            "tl.content, " +
+            "tl.location_summary as locationSummary, " +
+            "tl.like_count as likeCount, " +
+            "tl.comment_count as commentCount, " +
+            "tl.created_at as createdAt, " +
+            "u.nickname as authorNickname, " +
+            "u.profile_image_url as authorImageUrl, " +
+            "t.id as tripId, " +
+            "t.title as tripTitle " +
+            "FROM trip_log tl " +
+            "JOIN trip t ON tl.trip_id = t.id " +
+            "JOIN user u ON t.user_id = u.id " +
+            "WHERE tl.id = #{logId}")
+    @ConstructorArgs({
+            @Arg(column = "logId", javaType = Long.class),
+            @Arg(column = "title", javaType = String.class),
+            @Arg(column = "content", javaType = String.class),
+            @Arg(column = "locationSummary", javaType = String.class),
+            @Arg(column = "likeCount", javaType = int.class),
+            @Arg(column = "commentCount", javaType = int.class),
+            @Arg(column = "createdAt", javaType = LocalDateTime.class),
+            @Arg(column = "authorNickname", javaType = String.class),
+            @Arg(column = "authorImageUrl", javaType = String.class),
+            @Arg(column = "tripId", javaType = Long.class),
+            @Arg(column = "tripTitle", javaType = String.class)
+    })
+    Optional<TripLogDetailResponseDto.BaseInfo> findDetailById(Long logId);
+
+    @Select("SELECT " +
+            "image_ref_key, " +
+            "image_url, " +
+            "order_index " +
+            "FROM log_image " +
+            "WHERE log_id = #{logId} " +
+            "ORDER BY order_index ASC")
+    @ConstructorArgs({
+            @Arg(column = "image_ref_key", javaType = String.class),
+            @Arg(column = "image_url", javaType = String.class),
+            @Arg(column = "order_index", javaType = int.class)
+    })
+    List<TripLogImageResponseDto> findImagesByLogId(Long logId);
+
+    @Select("SELECT " +
+            "c.id as commentId, " +
+            "u.nickname as authorNickname, " +
+            "u.profile_image_url as authorImageUrl, " +
+            "c.content, " +
+            "c.created_at as createdAt " +
+            "FROM log_comment c " +
+            "JOIN user u ON c.user_id = u.id " +
+            "WHERE c.log_id = #{logId} " +
+            "ORDER BY c.created_at ASC")
+    @ConstructorArgs({
+            @Arg(column = "commentId", javaType = Long.class),
+            @Arg(column = "authorNickname", javaType = String.class),
+            @Arg(column = "authorImageUrl", javaType = String.class),
+            @Arg(column = "content", javaType = String.class),
+            @Arg(column = "createdAt", javaType = LocalDateTime.class)
+    })
+    List<TripLogCommentResponseDto> findCommentsByLogId(Long logId);
+}
+

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -1,0 +1,32 @@
+package com.ssafy.jjtrip.domain.triplog.service;
+
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
+import com.ssafy.jjtrip.domain.triplog.exception.TripLogErrorCode;
+import com.ssafy.jjtrip.domain.triplog.exception.TripLogException;
+import com.ssafy.jjtrip.domain.triplog.mapper.TripLogMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TripLogService {
+
+    private final TripLogMapper tripLogMapper;
+
+    public TripLogDetailResponseDto getTripLogDetail(Long logId) {
+        TripLogDetailResponseDto.BaseInfo baseInfo = tripLogMapper.findDetailById(logId)
+                .orElseThrow(() -> new TripLogException(TripLogErrorCode.LOG_NOT_FOUND));
+
+        List<TripLogImageResponseDto> images = tripLogMapper.findImagesByLogId(logId);
+
+        List<TripLogCommentResponseDto> comments = tripLogMapper.findCommentsByLogId(logId);
+
+        return TripLogDetailResponseDto.from(baseInfo, images, comments);
+    }
+}

--- a/src/main/resources/trit-db-setup.sql
+++ b/src/main/resources/trit-db-setup.sql
@@ -71,39 +71,6 @@ CREATE TABLE `friendship` (
   CONSTRAINT `chk_friendship_order` CHECK (`user_id_a` < `user_id_b`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
--- 여행 스타일 (Travel Style)
-CREATE TABLE `travel_style` (
-  `id`   BIGINT NOT NULL AUTO_INCREMENT,
-  `code` VARCHAR(20) NOT NULL UNIQUE, -- 'CAFE_LOVER'
-  `name` VARCHAR(50) NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 배지 (Badge)
-CREATE TABLE `badge` (
-  `id`          BIGINT NOT NULL AUTO_INCREMENT,
-  `code`        VARCHAR(50) NOT NULL UNIQUE,
-  `name`        VARCHAR(100) NOT NULL,
-  `description` VARCHAR(255),
-  `icon_url`    VARCHAR(255),
-  `category`    VARCHAR(30),
-  `level`       INT,
-  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `updated_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
--- 사용자 배지 (User Badge)
-CREATE TABLE `user_badge` (
-  `user_id`     BIGINT NOT NULL,
-  `badge_id`    BIGINT NOT NULL,
-  `obtained_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `is_pinned`   BOOLEAN NOT NULL DEFAULT FALSE,
-  PRIMARY KEY (`user_id`, `badge_id`),
-  CONSTRAINT `fk_user_badge_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
-  CONSTRAINT `fk_user_badge_badge` FOREIGN KEY (`badge_id`) REFERENCES `badge` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 -- ==========================================
 -- 🏢 2. 장소 (Spot Domain)
 -- ==========================================
@@ -173,6 +140,64 @@ CREATE TABLE `trip_item` (
   CONSTRAINT `fk_item_spot` FOREIGN KEY (`spot_id`) REFERENCES `spot` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+
+-- ==========================================
+-- ✍️ 4. 여행 기록 (Trip Log Domain)
+-- ==========================================
+
+-- 여행 기록 (Trip Log)
+CREATE TABLE `trip_log` (
+  `id`               BIGINT NOT NULL AUTO_INCREMENT,
+  `trip_id`          BIGINT NOT NULL,
+  `title`            VARCHAR(255) NOT NULL,
+  `content`          TEXT COMMENT '마크다운 형식 본문. 이미지는 {{img_key}} 형태의 참조 키 사용',
+  `location_summary` VARCHAR(255) COMMENT '장소 요약 (예: 서울시 or 서울시 강남구 or 서울시 강남구 역삼동)',
+  `like_count`       INT NOT NULL DEFAULT 0 COMMENT '좋아요 수',
+  `comment_count`    INT NOT NULL DEFAULT 0 COMMENT '댓글 수',
+  `created_at`       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_trip_log_trip_id` (`trip_id`), -- trip과 1:1 관계를 위해 UNIQUE 제약조건 추가
+  CONSTRAINT `fk_trip_log_trip` FOREIGN KEY (`trip_id`) REFERENCES `trip` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 여행 기록 좋아요 (Log Like)
+CREATE TABLE `log_like` (
+    `user_id`    BIGINT NOT NULL,
+    `log_id`     BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`user_id`, `log_id`), -- 한 사용자가 한 게시물에 좋아요를 한 번만 누를 수 있도록 복합키 설정
+    CONSTRAINT `fk_log_like_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE,
+    CONSTRAINT `fk_log_like_log` FOREIGN KEY (`log_id`) REFERENCES `trip_log` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 여행 기록 이미지 (Log Image)
+CREATE TABLE `log_image` (
+    `id`            BIGINT NOT NULL AUTO_INCREMENT,
+    `log_id`        BIGINT, -- 로그 저장 전 임시 업로드 상태일 수 있으므로 NULL 허용
+    `user_id`       BIGINT NOT NULL,
+    `image_url`     VARCHAR(255) NOT NULL,
+    `order_index`   INT NOT NULL COMMENT '인스타 피드 뷰에서의 표시 순서',
+    `image_ref_key` VARCHAR(50) NOT NULL COMMENT '본문 {{key}}와 매핑되는 고유 키 (프론트 생성)',
+    `created_at`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `fk_log_image_log` FOREIGN KEY (`log_id`) REFERENCES `trip_log` (`id`) ON DELETE SET NULL,
+    CONSTRAINT `fk_log_image_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 여행 기록 댓글 (Log Comment)
+CREATE TABLE `log_comment` (
+  `id`          BIGINT NOT NULL AUTO_INCREMENT,
+  `log_id`      BIGINT NOT NULL,
+  `user_id`     BIGINT NOT NULL,
+  `content`     TEXT NOT NULL,
+  `created_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_comment_log` FOREIGN KEY (`log_id`) REFERENCES `trip_log` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_comment_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 -- =================================================================
 -- 8. 시드 데이터 (초기 데이터)
 -- =================================================================
@@ -193,22 +218,11 @@ INSERT INTO `trip_status` (id, code, name, description) VALUES
 (2, 'PLANNED',   '계획 완료', '여행 계획 완료 상태'),
 (3, 'COMPLETED', '여행 완료', '여행이 실제로 완료된 상태');
 
--- 여행 스타일 (최소 데이터)
-INSERT INTO `travel_style` (id, code, name) VALUES
-(1, 'CAFE_HOPPER', '카페 탐방가'),
-(2, 'ADVENTURER', '모험가'),
-(3, 'FOODIE', '미식가');
-
--- 배지 (최소 데이터)
-INSERT INTO `badge` (id, code, name, description, icon_url, category, level) VALUES
-(1, 'FIRST_TRIP', '첫 여행', '첫 여행 계획 완료', NULL, 'TRIP', 1),
-(2, 'PHOTO_MASTER', '사진 장인', '사진 100장 업로드', NULL, 'PHOTO', 2);
-
 -- 더미 사용자 (사용자 제공 계정)
-INSERT INTO `user` (id, role_id, status_id, email, password_hash, nickname) VALUES
-(1, 1, 1, 'hi@hi.hi', '$2a$10$uyMhCnceQ3ORnCNk.wvfOeZt3EqtJNKzlD0OYZ.veOJYa2SgPFszu', '테스트 계정1'),
-(2, 1, 1, 'hi1@hi.hi', '$2a$10$uB2MdvuEvR460eGyC/H8w.j3ghCsBzLFRN7FOXpbG0vjCTx6o9n2K', '테스트 계정2'),
-(3, 1, 1, 'hi2@hi.hi', '$2a$10$1cA1Jc5KIeCCfBGAPKBbH.pt5dDiSKTgRX/j8aixQa1Pk8xB2Dreq', '테스트 계정3');
+INSERT INTO `user` (id, role_id, status_id, email, password_hash, nickname, profile_image_url) VALUES
+(1, 1, 1, 'hi@hi.hi', '$2a$10$uyMhCnceQ3ORnCNk.wvfOeZt3EqtJNKzlD0OYZ.veOJYa2SgPFszu', '테스트 계정1', 'https://dh.aks.ac.kr/Edu/wiki/images/b/b7/%ED%95%91%EA%B5%AC.jpg'),
+(2, 1, 1, 'hi1@hi.hi', '$2a$10$uB2MdvuEvR460eGyC/H8w.j3ghCsBzLFRN7FOXpbG0vjCTx6o9n2K', '테스트 계정2', 'https://i.namu.wiki/i/w4Vkm_EuVM_FV8-VDjLVJPWazkrT1YnkSFLVASCh4YM8QUebla94cM8j42z8hQPzJQCyVcDlm71EeKgPzLyMfg.webp'),
+(3, 1, 1, 'hi2@hi.hi', '$2a$10$1cA1Jc5KIeCCfBGAPKBbH.pt5dDiSKTgRX/j8aixQa1Pk8xB2Dreq', '테스트 계정3', 'https://i.namu.wiki/i/2Vk0cSYgfHODE4-SrICeOk7qaQCz09wqivf27QgdZawQ5lg3YKo-XjL9BvyvkBeQ-JGE_dV83cYnsd5urD65aw.webp');
 
 -- 더미 사용자 프로필 (사용자 제공 계정)
 INSERT INTO `user_profile` (user_id, bio, intro, friends_count) VALUES
@@ -220,17 +234,43 @@ INSERT INTO `user_profile` (user_id, bio, intro, friends_count) VALUES
 INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (1, 2);
 INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (1, 3);
 INSERT INTO `friendship` (user_id_a, user_id_b) VALUES (2, 3);
+
+-- 더미 장소
 INSERT INTO `spot` (kakao_place_id, name, address, category, lat, lng, place_url) VALUES
 ('27392064', '아쿠아플라넷 제주', '제주 서귀포시 성산읍 섭지코지로 95', '테마파크', 33.43041, 126.9242, 'http://place.map.kakao.com/27392064'),
 ('8035229', '성산일출봉', '제주 서귀포시 성산읍 성산리 1', '명소', 33.45806, 126.9425, 'http://place.map.kakao.com/8035229'),
 ('7948366', '카멜리아힐', '제주 서귀포시 안덕면 병악로 166', '공원', 33.2989, 126.3939, 'http://place.map.kakao.com/7948366');
 
 -- 더미 여행 계획
-INSERT INTO `trip` (user_id, trip_status_id, title, start_date, end_date, visibility) VALUES
-(1, 2, '제주도 2박 3일 여행', '2024-03-10', '2024-03-12', 'PUBLIC');
+INSERT INTO `trip` (id, user_id, trip_status_id, title, start_date, end_date, visibility) VALUES
+(1, 1, 2, '제주도 2박 3일 여행', '2024-03-10', '2024-03-12', 'PUBLIC');
 
 -- 더미 여행 아이템
 INSERT INTO `trip_item` (trip_id, spot_id, day_number, order_index, memo) VALUES
 (1, 1, 1, 1, '오전 10시 도착 예정'),
 (1, 2, 2, 1, '일출 보러 가기'),
 (1, 3, 2, 2, '점심 먹고 산책');
+
+-- 더미 여행 로그 (이미지 플레이스홀더 적용: 고유 키 방식)
+-- {{img_a1b2}} 처럼 프론트가 생성한 고유 키를 사용
+INSERT INTO `trip_log` (id, trip_id, title, content, location_summary, like_count, comment_count) VALUES
+(1, 1, '제주도 2박 3일 여행기',
+'이번 제주도 여행의 시작은 아쿠아플라넷이었습니다.\n\n{{img_key_1}}\n\n수족관 규모가 정말 커서 놀랐어요. 상어도 보고 가오리도 봤네요.\n그 다음날 아침에는 일출을 보러 갔습니다.\n\n{{img_key_2}}\n\n날씨가 좋아서 해 뜨는 게 아주 잘 보였습니다. 정말 잊지 못할 추억이에요.',
+'제주 서귀포시', 0, 0);
+
+-- 더미 여행 기록 이미지 (image_ref_key 포함)
+-- order_index: 피드 뷰 정렬용
+-- image_ref_key: 블로그 뷰 본문 매핑용
+INSERT INTO `log_image` (log_id, user_id, image_url, order_index, image_ref_key) VALUES
+(1, 1, 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQvytJIR9t4OyaATlDacK5xwsF7rd3yiMgWGQ&s', 0, 'img_key_1'),
+(1, 1, 'https://img1.daumcdn.net/thumb/R1280x0.fjpg/?fname=http://t1.daumcdn.net/brunch/service/user/1lcG/image/ATFUCOF_RrI4V7UWgZCF_g139sY.jpg', 1, 'img_key_2');
+
+-- 더미 로그 댓글
+INSERT INTO `log_comment` (log_id, user_id, content) VALUES
+(1, 2, '와 여행 너무 좋아보여요! 사진 멋지네요.'),
+(1, 3, '다음엔 저도 같이 가요 ㅎㅎ');
+
+-- 더미 로그 좋아요
+INSERT INTO `log_like` (user_id, log_id) VALUES
+(2, 1),
+(3, 1);


### PR DESCRIPTION
## Issue
- #27 

## Details
### 1. 구현 내용 (What)

`TripLog`의 상세 정보를 조회하는 API(`GET /api/trip-logs/{logId}`)를 구현했습니다.

이 API는 게시글의 기본 정보(제목, 본문 등), 작성자 정보, 연관된 여행 정보뿐 아니라 **이미지**와 **댓글 목록**까지 함께 반환하여, 여행 계획 상세 정보를 제외한 상세 페이지 구성에 필요한 모든 데이터를 단일 요청으로 제공합니다.

또한 `GET /api/trips/{logId}` 요청에 대한 접근 권한 조건을 수정하였습니다.

기존에는 인증된 사용자만 해당 엔드포인트에 접근할 수 있었지만, 아래와 같이 조건을 세분화하여 변경했습니다.

- 인증된 사용자: **PUBLIC** 계획과 **자신이 소유한 PRIVATE** 계획에 접근 가능
- 비인증 사용자(guest): **PUBLIC** 계획에만 접근 가능

---

### 2. 주요 설계 및 결정 이유 (Why)

#### 이미지 처리: 피드 뷰 + 블로그 뷰 동시 대응

##### ■ 문제(Problem)

* 피드에서는 이미지를 모아서 보여주고(Instagram 형식), 상세 페이지에서는 본문 사이에 삽입(블로그 형식)해야 하는 **서로 다른 UI 요구사항**이 있었습니다.
* 이미지 순서를 본문에 직접 저장할 경우, 수정 시 순서 재배치/삭제/추가 로직이 복잡해지는 문제가 예상되었습니다.

##### ■ 해결(Solution)

* 본문(`content`)에는 실제 URL 대신 `{{img_ref_key}}` 형태의 **고유 플레이스홀더**를 저장합니다.
* `log_image` 테이블을 추가하여 `image_ref_key`, `order_index`, `image_url`을 함께 관리하도록 했습니다.

##### ■ 기대 효과(Benefit)

* 프론트는 ‘플레이스홀더가 포함된 본문’과 ‘정렬된 이미지 목록’을 활용해 피드/블로그 뷰를 유연하게 렌더링할 수 있습니다.
* 백엔드는 이미지 수정 시 `image_ref_key` 기준으로 처리하면 되므로, 복잡한 본문 파싱 없이 로직을 단순하게 유지할 수 있습니다.

---

### 3. API 명세 (API Specification)

#### `GET /api/trip-logs/{logId}`

#### Response 예시 (200 OK)
```json
{
  "logId": 12,
  "title": "부산 여행 첫날",
  "content": "광안리 도착! {{img_key_1}} 정말 예뻤다...",
  "locationSummary": "부산 광안리, 해운대",
  "likeCount": 12,
  "commentCount": 3,
  "createdAt": "2025-01-14T12:30:00",
  "author": {
    "nickname": "jihyeon",
    "imageUrl": "https://example.com/profile.jpg"
  },
  "trip": {
    "tripId": 3,
    "title": "부산 2박 3일"
  },
  "images": [
    {
      "imageRefKey": "img_key_1",
      "imageUrl": "https://example.com/img1.jpg",
      "orderIndex": 1
    },
    {
      "imageRefKey": "img_key_2",
      "imageUrl": "https://example.com/img2.jpg",
      "orderIndex": 2
    }
  ],
  "comments": [
    {
      "commentId": 1,
      "authorNickname": "jay",
      "authorImageUrl": "https://example.com/jay.jpg",
      "content": "너무 예쁘네요!",
      "createdAt": "2025-01-14T13:00:00"
    }
  ]
}
```

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/369404d3-6783-4a0c-9083-ad8abbb11d2a" />


---

### 4. 트러블슈팅 및 개선 (Troubleshooting & Refinements)

#### MyBatis + Java Record 매핑 문제

* **문제**: 초기 구현 시 MyBatis가 `Record` DTO를 생성하지 못해 `ReflectionException`(Setter 없음)이 발생했습니다.
* **원인**: MyBatis가 기본적으로 Setter를 통한 객체 생성 방식을 기대하기 때문입니다.
* **해결**: `@ConstructorArgs`를 적용해 생성자 기반 매핑으로 전환했습니다.

#### DTO 생성 책임 분리

* **문제**: Mapper가 반환하는 조각과 Service에서 결합하는 로직이 복잡해지고, 객체 생성 책임이 Service에 과도하게 쏠렸습니다.
* **개선**: DTO 내부에 조회용 이너 레코드(`BaseInfo`)를 두고, `static from` 팩토리 메서드로 최종 DTO를 조립하도록 변경했습니다. 결과적으로 서비스 로직이 단순해지고 DTO의 불변성을 유지할 수 있었습니다.