### PR TITLE
feat: 여행 기록 댓글 추가 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
@@ -1,12 +1,16 @@
 package com.ssafy.jjtrip.domain.triplog.controller;
 
+import com.ssafy.jjtrip.common.security.CustomUserDetails;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.service.TripLogService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,5 +22,15 @@ public class TripLogController {
     @GetMapping("/{logId}")
     public TripLogDetailResponseDto getTripLogDetail(@PathVariable Long logId) {
         return tripLogService.getTripLogDetail(logId);
+    }
+
+    @PostMapping("/{logId}/comments")
+    public ResponseEntity<Void> addComment(
+            @PathVariable Long logId,
+            @Valid @RequestBody TripLogCommentRequestDto commentRequestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        tripLogService.addComment(logId, userDetails.getUser().getId(), commentRequestDto);
+        return ResponseEntity.created(URI.create("/trip-logs/" + logId)).build();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogCommentRequestDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogCommentRequestDto.java
@@ -1,0 +1,9 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TripLogCommentRequestDto(
+    @NotBlank(message = "댓글 내용은 필수 입력값입니다.")
+    String content
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -3,10 +3,8 @@ package com.ssafy.jjtrip.domain.triplog.mapper;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
-import org.apache.ibatis.annotations.Arg;
-import org.apache.ibatis.annotations.ConstructorArgs;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Select;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLogComment;
+import org.apache.ibatis.annotations.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -78,5 +76,16 @@ public interface TripLogMapper {
             @Arg(column = "createdAt", javaType = LocalDateTime.class)
     })
     List<TripLogCommentResponseDto> findCommentsByLogId(Long logId);
+
+    @Select("SELECT EXISTS(SELECT 1 FROM trip_log WHERE id = #{logId})")
+    boolean existsById(Long logId);
+
+    @Insert("INSERT INTO log_comment (log_id, user_id, content) " +
+            "VALUES (#{comment.logId}, #{comment.userId}, #{comment.content})")
+    @Options(useGeneratedKeys = true, keyProperty = "comment.id")
+    void insertComment(@Param("comment") TripLogComment comment);
+
+    @Update("UPDATE trip_log SET comment_count = comment_count + 1 WHERE id = #{logId}")
+    void incrementCommentCount(Long logId);
 }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -1,8 +1,10 @@
 package com.ssafy.jjtrip.domain.triplog.service;
 
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLogComment;
 import com.ssafy.jjtrip.domain.triplog.exception.TripLogErrorCode;
 import com.ssafy.jjtrip.domain.triplog.exception.TripLogException;
 import com.ssafy.jjtrip.domain.triplog.mapper.TripLogMapper;
@@ -28,5 +30,20 @@ public class TripLogService {
         List<TripLogCommentResponseDto> comments = tripLogMapper.findCommentsByLogId(logId);
 
         return TripLogDetailResponseDto.from(baseInfo, images, comments);
+    }
+
+    @Transactional
+    public void addComment(Long logId, Long userId, TripLogCommentRequestDto commentRequestDto) {
+        if (!tripLogMapper.existsById(logId)) {
+            throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
+        }
+
+        TripLogComment comment = TripLogComment.builder()
+                .logId(logId)
+                .userId(userId)
+                .content(commentRequestDto.content())
+                .build();
+        tripLogMapper.insertComment(comment);
+        tripLogMapper.incrementCommentCount(logId);
     }
 }


### PR DESCRIPTION
## Issue
- close #29 

## Details
   - 여행 기록(Trip Log)에 댓글을 추가하는 기능을 구현했습니다.
   - POST /api/trip-logs/{logId}/comments API 엔드포인트를 추가했습니다.
   - TripLogController, TripLogService, TripLogMapper에 댓글 생성 관련 로직을 추가하여 기존 아키텍처의 일관성을 유지했습니다.
   - 요청 처리를 위한 TripLogCommentRequestDto를 생성했습니다.
   - 댓글 추가 전, 대상 여행 기록이 존재하는지 확인하는 검증 로직을 추가하여 안정성을 높였습니다.
   - main-feed-api.yml OpenAPI 명세에 신규 API 정보를 업데이트했습니다.

### API 명세

`POST /api/trip-logs/{logId}/comments`
`"authentication": "필수 (Bearer Token)"`

```json
{
    "request": {
        "content": "string // 댓글 내용"
    }
}
```

 ### 참고 사항
   - TripLogService의 addComment 메서드는 @Transactional로 처리되어, 댓글 레코드 생성과 trip_log 테이블의 comment_count
     업데이트가 원자적으로 실행됩니다.
   - 인증된 사용자만 댓글을 작성할 수 있도록 SecurityConfig에 기반한 인증이 필요하며, API 명세의 security 항목에 bearerAuth를
     추가했습니다.