### PR TITLE
feat: TripLog 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
@@ -3,6 +3,7 @@ package com.ssafy.jjtrip.domain.triplog.controller;
 import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogLikeResponseDto;
 import com.ssafy.jjtrip.domain.triplog.service.TripLogService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -20,17 +21,44 @@ public class TripLogController {
     private final TripLogService tripLogService;
 
     @GetMapping("/{logId}")
-    public TripLogDetailResponseDto getTripLogDetail(@PathVariable Long logId) {
-        return tripLogService.getTripLogDetail(logId);
+    public ResponseEntity<?> getTripLogDetail(@PathVariable Long logId) {
+        return ResponseEntity.ok(tripLogService.getTripLogDetail(logId));
     }
 
     @PostMapping("/{logId}/comments")
-    public ResponseEntity<Void> addComment(
+    public ResponseEntity<?> addComment(
             @PathVariable Long logId,
             @Valid @RequestBody TripLogCommentRequestDto commentRequestDto,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         tripLogService.addComment(logId, userDetails.getUser().getId(), commentRequestDto);
         return ResponseEntity.created(URI.create("/trip-logs/" + logId)).build();
+    }
+
+    @GetMapping("/{logId}/likes/status")
+    public ResponseEntity<?> getLikeStatus(
+            @PathVariable Long logId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripLogLikeResponseDto response = tripLogService.getLikeStatus(logId, userDetails.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{logId}/likes")
+    public ResponseEntity<?> likeTripLog(
+            @PathVariable Long logId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripLogLikeResponseDto response = tripLogService.likeTripLog(logId, userDetails.getUser().getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{logId}/likes")
+    public ResponseEntity<?> unlikeTripLog(
+            @PathVariable Long logId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        TripLogLikeResponseDto response = tripLogService.unlikeTripLog(logId, userDetails.getUser().getId());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogDetailResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogDetailResponseDto.java
@@ -8,23 +8,21 @@ public record TripLogDetailResponseDto(
         String title,
         String content,
         String locationSummary,
-        int likeCount,
-        int commentCount,
         LocalDateTime createdAt,
         String authorNickname,
         String authorImageUrl,
         Long tripId,
         String tripTitle,
         List<TripLogImageResponseDto> images,
-        List<TripLogCommentResponseDto> comments
+        List<TripLogCommentResponseDto> comments,
+        int likeCount,
+        int commentCount
 ) {
     public record BaseInfo(
             Long logId,
             String title,
             String content,
             String locationSummary,
-            int likeCount,
-            int commentCount,
             LocalDateTime createdAt,
             String authorNickname,
             String authorImageUrl,
@@ -33,22 +31,26 @@ public record TripLogDetailResponseDto(
     ) {}
 
     public static TripLogDetailResponseDto from(
-            BaseInfo baseInfo, List<TripLogImageResponseDto> images, List<TripLogCommentResponseDto> comments
+            BaseInfo baseInfo,
+            List<TripLogImageResponseDto> images,
+            List<TripLogCommentResponseDto> comments,
+            int likeCount,
+            int commentCount
     ) {
         return new TripLogDetailResponseDto(
                 baseInfo.logId(),
                 baseInfo.title(),
                 baseInfo.content(),
                 baseInfo.locationSummary(),
-                baseInfo.likeCount(),
-                baseInfo.commentCount(),
                 baseInfo.createdAt(),
                 baseInfo.authorNickname(),
                 baseInfo.authorImageUrl(),
                 baseInfo.tripId(),
                 baseInfo.tripTitle(),
                 images,
-                comments
+                comments,
+                likeCount,
+                commentCount
         );
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogLikeResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogLikeResponseDto.java
@@ -1,0 +1,7 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+public record TripLogLikeResponseDto(
+    boolean liked,
+    int likeCount
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLog.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/entity/TripLog.java
@@ -19,8 +19,6 @@ public class TripLog extends BaseEntityWithUpdate {
     private String title;
     private String content;
     private String locationSummary;
-    private Integer likeCount;
-    private Integer commentCount;
 
     private Trip trip;
     private List<TripLogImage> images;

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -18,8 +18,6 @@ public interface TripLogMapper {
             "tl.title, " +
             "tl.content, " +
             "tl.location_summary as locationSummary, " +
-            "tl.like_count as likeCount, " +
-            "tl.comment_count as commentCount, " +
             "tl.created_at as createdAt, " +
             "u.nickname as authorNickname, " +
             "u.profile_image_url as authorImageUrl, " +
@@ -34,8 +32,6 @@ public interface TripLogMapper {
             @Arg(column = "title", javaType = String.class),
             @Arg(column = "content", javaType = String.class),
             @Arg(column = "locationSummary", javaType = String.class),
-            @Arg(column = "likeCount", javaType = int.class),
-            @Arg(column = "commentCount", javaType = int.class),
             @Arg(column = "createdAt", javaType = LocalDateTime.class),
             @Arg(column = "authorNickname", javaType = String.class),
             @Arg(column = "authorImageUrl", javaType = String.class),
@@ -85,26 +81,18 @@ public interface TripLogMapper {
     @Options(useGeneratedKeys = true, keyProperty = "comment.id")
     void insertComment(@Param("comment") TripLogComment comment);
 
-    @Update("UPDATE trip_log SET comment_count = comment_count + 1 WHERE id = #{logId}")
-    void incrementCommentCount(Long logId);
+    @Select("SELECT COUNT(*) FROM log_comment WHERE log_id = #{logId}")
+    int getCommentCount(Long logId);
 
-    // Like/Unlike methods
     @Insert("INSERT IGNORE INTO log_like (log_id, user_id) VALUES (#{logId}, #{userId})")
     void insertLike(@Param("logId") Long logId, @Param("userId") Long userId);
 
     @Delete("DELETE FROM log_like WHERE log_id = #{logId} AND user_id = #{userId}")
     void deleteLike(@Param("logId") Long logId, @Param("userId") Long userId);
 
-    @Update("UPDATE trip_log SET like_count = like_count + 1 WHERE id = #{logId}")
-    void incrementLikeCount(Long logId);
-
-    @Update("UPDATE trip_log SET like_count = like_count - 1 WHERE id = #{logId}")
-    void decrementLikeCount(Long logId);
-
     @Select("SELECT EXISTS(SELECT 1 FROM log_like WHERE log_id = #{logId} AND user_id = #{userId})")
     boolean hasUserLiked(@Param("logId") Long logId, @Param("userId") Long userId);
 
-    @Select("SELECT like_count FROM trip_log WHERE id = #{logId}")
+    @Select("SELECT COUNT(*) FROM log_like WHERE log_id = #{logId}")
     int getLikeCount(Long logId);
 }
-

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -87,5 +87,24 @@ public interface TripLogMapper {
 
     @Update("UPDATE trip_log SET comment_count = comment_count + 1 WHERE id = #{logId}")
     void incrementCommentCount(Long logId);
+
+    // Like/Unlike methods
+    @Insert("INSERT IGNORE INTO log_like (log_id, user_id) VALUES (#{logId}, #{userId})")
+    void insertLike(@Param("logId") Long logId, @Param("userId") Long userId);
+
+    @Delete("DELETE FROM log_like WHERE log_id = #{logId} AND user_id = #{userId}")
+    void deleteLike(@Param("logId") Long logId, @Param("userId") Long userId);
+
+    @Update("UPDATE trip_log SET like_count = like_count + 1 WHERE id = #{logId}")
+    void incrementLikeCount(Long logId);
+
+    @Update("UPDATE trip_log SET like_count = like_count - 1 WHERE id = #{logId}")
+    void decrementLikeCount(Long logId);
+
+    @Select("SELECT EXISTS(SELECT 1 FROM log_like WHERE log_id = #{logId} AND user_id = #{userId})")
+    boolean hasUserLiked(@Param("logId") Long logId, @Param("userId") Long userId);
+
+    @Select("SELECT like_count FROM trip_log WHERE id = #{logId}")
+    int getLikeCount(Long logId);
 }
 

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -4,6 +4,7 @@ import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogLikeResponseDto;
 import com.ssafy.jjtrip.domain.triplog.entity.TripLogComment;
 import com.ssafy.jjtrip.domain.triplog.exception.TripLogErrorCode;
 import com.ssafy.jjtrip.domain.triplog.exception.TripLogException;
@@ -45,5 +46,36 @@ public class TripLogService {
                 .build();
         tripLogMapper.insertComment(comment);
         tripLogMapper.incrementCommentCount(logId);
+    }
+
+    public TripLogLikeResponseDto getLikeStatus(Long logId, Long userId) {
+        if (!tripLogMapper.existsById(logId)) {
+            throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
+        }
+        boolean liked = tripLogMapper.hasUserLiked(logId, userId);
+        int likeCount = tripLogMapper.getLikeCount(logId);
+        return new TripLogLikeResponseDto(liked, likeCount);
+    }
+
+    @Transactional
+    public TripLogLikeResponseDto likeTripLog(Long logId, Long userId) {
+        if (!tripLogMapper.existsById(logId)) {
+            throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
+        }
+        tripLogMapper.insertLike(logId, userId);
+        tripLogMapper.incrementLikeCount(logId);
+        int likeCount = tripLogMapper.getLikeCount(logId);
+        return new TripLogLikeResponseDto(true, likeCount);
+    }
+
+    @Transactional
+    public TripLogLikeResponseDto unlikeTripLog(Long logId, Long userId) {
+        if (!tripLogMapper.existsById(logId)) {
+            throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
+        }
+        tripLogMapper.deleteLike(logId, userId);
+        tripLogMapper.decrementLikeCount(logId);
+        int likeCount = tripLogMapper.getLikeCount(logId);
+        return new TripLogLikeResponseDto(false, likeCount);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -27,10 +27,12 @@ public class TripLogService {
                 .orElseThrow(() -> new TripLogException(TripLogErrorCode.LOG_NOT_FOUND));
 
         List<TripLogImageResponseDto> images = tripLogMapper.findImagesByLogId(logId);
-
         List<TripLogCommentResponseDto> comments = tripLogMapper.findCommentsByLogId(logId);
 
-        return TripLogDetailResponseDto.from(baseInfo, images, comments);
+        int likeCount = tripLogMapper.getLikeCount(logId);
+        int commentCount = tripLogMapper.getCommentCount(logId);
+
+        return TripLogDetailResponseDto.from(baseInfo, images, comments, likeCount, commentCount);
     }
 
     @Transactional
@@ -45,7 +47,6 @@ public class TripLogService {
                 .content(commentRequestDto.content())
                 .build();
         tripLogMapper.insertComment(comment);
-        tripLogMapper.incrementCommentCount(logId);
     }
 
     public TripLogLikeResponseDto getLikeStatus(Long logId, Long userId) {
@@ -63,7 +64,6 @@ public class TripLogService {
             throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
         }
         tripLogMapper.insertLike(logId, userId);
-        tripLogMapper.incrementLikeCount(logId);
         int likeCount = tripLogMapper.getLikeCount(logId);
         return new TripLogLikeResponseDto(true, likeCount);
     }
@@ -74,7 +74,6 @@ public class TripLogService {
             throw new TripLogException(TripLogErrorCode.LOG_NOT_FOUND);
         }
         tripLogMapper.deleteLike(logId, userId);
-        tripLogMapper.decrementLikeCount(logId);
         int likeCount = tripLogMapper.getLikeCount(logId);
         return new TripLogLikeResponseDto(false, likeCount);
     }

--- a/src/main/resources/trit-db-setup.sql
+++ b/src/main/resources/trit-db-setup.sql
@@ -152,8 +152,6 @@ CREATE TABLE `trip_log` (
   `title`            VARCHAR(255) NOT NULL,
   `content`          TEXT COMMENT '마크다운 형식 본문. 이미지는 {{img_key}} 형태의 참조 키 사용',
   `location_summary` VARCHAR(255) COMMENT '장소 요약 (예: 서울시 or 서울시 강남구 or 서울시 강남구 역삼동)',
-  `like_count`       INT NOT NULL DEFAULT 0 COMMENT '좋아요 수',
-  `comment_count`    INT NOT NULL DEFAULT 0 COMMENT '댓글 수',
   `created_at`       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at`       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
@@ -253,10 +251,10 @@ INSERT INTO `trip_item` (trip_id, spot_id, day_number, order_index, memo) VALUES
 
 -- 더미 여행 로그 (이미지 플레이스홀더 적용: 고유 키 방식)
 -- {{img_a1b2}} 처럼 프론트가 생성한 고유 키를 사용
-INSERT INTO `trip_log` (id, trip_id, title, content, location_summary, like_count, comment_count) VALUES
+INSERT INTO `trip_log` (id, trip_id, title, content, location_summary) VALUES
 (1, 1, '제주도 2박 3일 여행기',
 '이번 제주도 여행의 시작은 아쿠아플라넷이었습니다.\n\n{{img_key_1}}\n\n수족관 규모가 정말 커서 놀랐어요. 상어도 보고 가오리도 봤네요.\n그 다음날 아침에는 일출을 보러 갔습니다.\n\n{{img_key_2}}\n\n날씨가 좋아서 해 뜨는 게 아주 잘 보였습니다. 정말 잊지 못할 추억이에요.',
-'제주 서귀포시', 0, 0);
+'제주 서귀포시');
 
 -- 더미 여행 기록 이미지 (image_ref_key 포함)
 -- order_index: 피드 뷰 정렬용


### PR DESCRIPTION
## Issue
- close #31 

## Details

이 PR은 TripLog의 좋아요 기능을 구현하는 과정에서 발견된 문제들을 정리하고, 이를 해결하기 위한 개선 사항을 포함하고 있습니다.
초기 구현부터 구조적 고민, INSERT IGNORE에 대한 조사, 프론트 요구사항 반영, 데이터 정합성 문제 해결까지의 흐름을 정리해보았습니다.

---

### **1. 좋아요 기능의 초기 구현과 한계**

처음 좋아요 기능을 구현할 때에는 다음과 같이 단순한 API 형태로 만들었습니다.

* **POST /api/trip-logs/likes** → 좋아요 추가 → `200 OK`
* **DELETE /api/trip-logs/likes/{logId}** → 좋아요 취소 → `204 No Content`

이 방식은 요청이 성공했는지 실패했는지를 프론트가 확인할 수 있다는 점에서 직관적이고 간단했습니다.
하지만, 이 구조가 실제로 좋아요 UI를 구현하는 데 충분하지 않다는 점이 이후 드러났습니다.

---

### **2. INSERT IGNORE 사용에서 발생한 문제**

좋아요 테이블에는 `(user_id, log_id)`에 대해 Unique 제약이 걸려 있습니다.
중복 좋아요를 방지하기 위해 가장 단순하고 효율적인 방법으로 MySQL의 `INSERT IGNORE`를 사용했습니다.

하지만 여기서 중요한 문제가 나타났습니다.

#### **2-1. INSERT IGNORE의 동작 방식**

INSERT IGNORE는 다음과 같이 동작합니다:

* 새로운 좋아요 → 정상 삽입
* **이미 좋아요가 있는 경우 → 삽입을 무시하고도 200 OK 반환**
* strict mode에서도 오류가 나지 않고 Warning만 발생
* 즉, 중복 삽입이 일어나도 트랜잭션 흐름이 끊기지 않음

#### **2-2. INSERT IGNORE에 대해 고민했던 이유**

INSERT IGNORE는 편리하지만 다음과 같은 고민 포인트가 있었습니다.

* MySQL 전용 문법이기 때문에 **DB 의존성이 생김**
* 좋아요가 새로 생성된 것인지, 중복이라 무시된 것인지 **구분 불가**
* 프론트는 하트 UI를 결정해야 하는데, 항상 200 OK만 받으니 판단할 수 없음

다른 데이터베이스에서도 PostgreSQL의 `ON CONFLICT DO NOTHING` 등 유사 기능은 존재하지만,
각 DB마다 문구와 동작 방식이 다르기 때문에 코드 이식성을 생각하면 고민이 되었습니다.

#### **2-3. 결론 — 우리 서비스에서는 INSERT IGNORE가 최적의 선택**

고민 끝에 다음과 같은 이유로 INSERT IGNORE를 계속 사용하기로 결정했습니다.

* 현재 서비스는 MySQL을 기반으로 하고 있음
* SELECT 후 INSERT 방식은 동시성 문제가 발생할 수 있음
* 성능 측면에서도 INSERT IGNORE 방식이 더 단순하고 효율적임
* 좋아요 기능은 읽기/쓰기 요청이 잦기 때문에 복잡성을 낮추는 것이 중요함

따라서 INSERT IGNORE는 유지하되,
그로 인해 생긴 문제점(중복 여부 판단 불가)은 **응답 구조 개선으로 해결하기로 결정**했습니다.

---

### **3. 프론트 요구사항에 따른 응답 구조 개선**

프론트에서는 좋아요 버튼을 눌렀을 때 다음 정보가 필요했습니다.

* 현재 사용자가 좋아요를 누른 상태인지 (`liked`)
* 좋아요 총 개수가 몇 개인지 (`likeCount`)

하지만 기존 POST/DELETE 응답은 성공 여부만 전달했기 때문에 상호작용에 필요한 데이터가 부족했습니다.

#### **3-1. 개선 사항**

좋아요 관련 API는 다음 정보를 포함하도록 수정했습니다.

```json
{
  "liked": true,
  "likeCount": 13
}
```

이를 통해 프론트는

* 요청 직후 UI를 정확하게 업데이트할 수 있고
* 새로고침 시에도 일관된 상태를 유지할 수 있습니다.

---

### **4. 좋아요 상태 조회 API 추가**

프론트에서는 페이지 진입 시 또는 새로고침 시 “현재 이 사용자가 좋아요를 눌렀는지” 확인해야 했습니다.

이를 위해 다음 API를 추가했습니다.

**GET /api/trip-logs/{logId}/likes/status**

Response 예시는 다음과 같습니다.

```json
{
  "liked": true,
  "likeCount": 12
}
```

이 API는 프론트가 초기 상태를 정확하게 설정할 수 있게 하는 핵심 요소입니다.

---

### **5. TripLog 내부 캐싱 필드 제거 (정합성 문제 해결)**

초기에는 `TripLog` 엔티티 내부에 다음 두 필드를 캐싱처럼 저장해두려 했습니다.

* `likeCount`
* `commentCount`

하지만 이 방식은 **실제 DB 상태와 불일치가 발생할 수 있어 문제가 되었습니다.**

예를 들어:

* 동시 좋아요 요청
* 좋아요 취소 후 즉시 좋아요 재요청
* 댓글 추가/삭제 시점 차이

이런 상황에서 캐싱된 값은 언제든지 오염될 가능성이 있었습니다.

#### **따라서, 이번 PR에서는 다음과 같이 처리했습니다:**

* TripLog 엔티티 내부의 `likeCount`, `commentCount` 필드를 **완전히 제거했습니다.**
* 모든 count 값은 실제 테이블을 기준으로 조회하도록 변경했습니다.
* 추후 성능 문제가 생기면 Redis counter 등으로 확장할 수 있습니다.

정합성을 우선하는 것이 현재 단계에서는 올바르다고 판단했습니다.

---

### **6. 마무리**

이번 PR은 다음 문제들을 해결하기 위한 일련의 개선 작업입니다.

* INSERT IGNORE 사용에 대한 구조적 고민
* 프론트 UI가 필요한 정보를 안정적으로 받을 수 있도록 응답 구조 개선
* 좋아요 여부를 조회할 수 있는 전용 API 추가
* TripLog 내부 캐싱 필드 제거로 데이터 정합성 확보

이 과정에서 기능의 안정성과 단순성을 유지하면서도
프론트와의 연동이 명확해지는 방향으로 정리했습니다.

앞으로 좋아요 기능에 대한 성능 최적화가 필요해지면,
Redis 기반 카운터나 별도의 집계 테이블 도입을 고려할 수 있습니다.