### PR TITLE
feat: develop 브랜치 dev CI/CD 파이프라인 구축 (GHCR + KT Cloud 배포)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,105 @@
+name: Dev Deploy
+
+on:
+  push:
+    branches: [ "develop" ]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  ci:
+    name: CI (maven test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: maven
+
+      - name: Test
+        run: |
+          chmod +x mvnw
+          ./mvnw test
+
+  build_and_push:
+    name: Build & Push (GHCR)
+    runs-on: ubuntu-latest
+    needs: ci
+
+    outputs:
+      image_tag: ${{ steps.vars.outputs.image_tag }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: vars
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          echo "image_tag=sha-${SHORT_SHA}" >> $GITHUB_OUTPUT
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./deploy/app/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.vars.outputs.image_tag }}
+
+  deploy:
+    name: Deploy to Dev Server
+    runs-on: ubuntu-latest
+    needs: build_and_push
+    environment: dev
+
+    steps:
+      - name: Deploy via SSH (update IMAGE_NAME, pull, up)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.KT_HOST }}
+          username: ${{ secrets.KT_USER }}
+          key: ${{ secrets.KT_SSH_KEY }}
+          port: ${{ secrets.KT_SSH_PORT }}
+          script: |
+            set -e
+            cd /home/${{ secrets.KT_USER }}/trit-server
+
+            # (선택) compose/nginx 설정 변경을 같이 반영하고 싶으면 유지
+            git pull origin develop
+
+            # IMAGE_NAME을 이번 커밋 이미지로 업데이트 (서버 .env에 IMAGE_NAME이 있어야 함)
+            NEW_IMAGE="ghcr.io/${{ github.repository }}:${{ needs.build_and_push.outputs.image_tag }}"
+
+            if [ ! -f .env ]; then
+              echo ".env not found in $(pwd). Create it first." >&2
+              exit 1
+            fi
+
+            if grep -q '^IMAGE_NAME=' .env; then
+              sed -i "s|^IMAGE_NAME=.*|IMAGE_NAME=${NEW_IMAGE}|" .env
+            else
+              echo "IMAGE_NAME=${NEW_IMAGE}" >> .env
+            fi
+
+            docker compose pull app
+            docker compose up -d
+            docker image prune -f

--- a/deploy/app/Dockerfile
+++ b/deploy/app/Dockerfile
@@ -1,0 +1,22 @@
+# 1) Build stage
+FROM eclipse-temurin:17-jdk AS builder
+WORKDIR /app
+
+# 먼저 의존성 캐시(빌드 빨라짐)
+COPY pom.xml ./
+COPY .mvn .mvn
+COPY mvnw ./
+RUN chmod +x mvnw
+RUN ./mvnw -q -DskipTests dependency:go-offline
+
+# 소스 복사 후 패키징
+COPY src src
+RUN ./mvnw -DskipTests package
+
+# 2) Run stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=builder /app/target/*.jar app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/deploy/nginx/conf.d/default.conf
+++ b/deploy/nginx/conf.d/default.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://app:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: "3.8"
 
 services:
   app:
-    build:
-      context: .
-      dockerfile: ./deploy/app/Dockerfile
+    image: ${IMAGE_NAME}
     container_name: trit-app
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,151 @@
+version: "3.8"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: ./deploy/app/Dockerfile
+    container_name: trit-app
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-dev}
+      SERVER_PORT: 8080
+
+      DB_HOST: mysql
+      DB_PORT: 3306
+      DB_NAME: ${DB_NAME:-trit_dev}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+
+      SMTP_USERNAME: ${SMTP_USERNAME}
+      SMTP_PASSWORD: ${SMTP_PASSWORD}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+
+    networks:
+      - trit-net
+    expose:
+      - "8080"
+
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: trit-nginx
+    restart: unless-stopped
+    depends_on:
+      - app
+    ports:
+      - "80:80"
+    volumes:
+      - ./deploy/nginx/conf.d:/etc/nginx/conf.d:ro
+    networks:
+      - trit-net
+
+  mysql:
+    image: mysql:8.0
+    container_name: trit-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      TZ: Asia/Seoul
+    command:
+      [
+        "mysqld",
+        "--character-set-server=utf8mb4",
+        "--collation-server=utf8mb4_unicode_ci",
+        "--default-time-zone=+09:00"
+      ]
+    ports:
+      - "127.0.0.1:3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - trit-net
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -u${DB_USER} -p${DB_PASSWORD} --silent"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+
+  redis:
+    image: redis:7-alpine
+    container_name: trit-redis
+    restart: unless-stopped
+    command:
+      [
+        "redis-server",
+        "--appendonly", "yes",
+        "--requirepass", "${REDIS_PASSWORD}"
+      ]
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - trit-net
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 10s
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: trit-es
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+      - ES_JAVA_OPTS=${ES_JAVA_OPTS}
+    ports:
+      - "127.0.0.1:9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    networks:
+      - trit-net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:9200 >/dev/null || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
+      start_period: 20s
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    container_name: trit-kibana
+    restart: unless-stopped
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "127.0.0.1:5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    networks:
+      - trit-net
+
+networks:
+  trit-net:
+    driver: bridge
+
+volumes:
+  mysql_data:
+  redis_data:
+  es_data:

--- a/src/main/java/com/ssafy/jjtrip/common/config/SshTunnelingInitializer.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SshTunnelingInitializer.java
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-@Profile("!test") // 테스트 환경에서는 실행되지 않도록 설정
+@Profile("!dev")
 @Configuration
 @EnableConfigurationProperties(SshTunnelingProperties.class)
 public class SshTunnelingInitializer {

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
@@ -59,8 +59,8 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .maxAge(0)
                 .path("/")
-                .secure(true)
-                .sameSite("None")
+                .secure(false)
+                .sameSite("Lax")
                 .httpOnly(true)
                 .build();
 


### PR DESCRIPTION
## 변경 사항

* GitHub Actions 기반 **CI/CD 파이프라인(dev)** 추가
* Maven 테스트를 포함한 **CI 단계 구성**
* Docker 이미지 **GHCR 빌드 & 푸시** 자동화

  * `dev` 고정 태그
  * `sha-xxxx` 커밋 추적 태그
* KT Cloud 서버로 **SSH 배포 자동화**

  * `.env`의 `IMAGE_NAME`을 커밋 sha 태그로 갱신
  * `docker compose pull app && up -d` 방식으로 재기동

## 배포 흐름

1. `develop` 브랜치 push
2. CI: Maven 테스트 실행
3. Build: Docker 이미지 빌드 후 GHCR 업로드
4. Deploy:

   * KT Cloud 서버 SSH 접속
   * 최신 compose 설정 pull
   * `IMAGE_NAME` 업데이트
   * app 컨테이너 재배포

## 참고 사항

* 배포 서버 접근 정보는 **GitHub Environment(dev) secrets** 사용
* prod 환경 확장을 고려한 **태그 전략(dev / sha)** 적용
