### PR TITLE
fix: cross-site 환경에서 refreshToken 쿠키 저장 이슈 해결

### DIFF
--- a/deploy/nginx/conf.d/default.conf
+++ b/deploy/nginx/conf.d/default.conf
@@ -1,5 +1,15 @@
 server {
     listen 80;
+    server_name tritt.o-r.kr;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name tritt.o-r.kr;
+
+    ssl_certificate     /etc/letsencrypt/live/tritt.o-r.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/tritt.o-r.kr/privkey.pem;
 
     location / {
         proxy_pass http://app:8080;
@@ -8,6 +18,6 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto https;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,10 @@ services:
       - app
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./deploy/nginx/conf.d:/etc/nginx/conf.d:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     networks:
       - trit-net
 

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/controller/AuthController.java
@@ -59,8 +59,8 @@ public class AuthController {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, "")
                 .maxAge(0)
                 .path("/")
-                .secure(false)
-                .sameSite("Lax")
+                .secure(true)
+                .sameSite("None")
                 .httpOnly(true)
                 .build();
 


### PR DESCRIPTION
## Issue
- close #42 

## Details
### 문제 상황

* `http://localhost:5173`(프론트) ↔ `http://tritt.o-r.kr`(백엔드) 환경에서
  Chrome 브라우저에서 **refreshToken 쿠키가 정상적으로 저장되지 않는 문제**가 발생함.

### 원인 분석

* 프론트와 백엔드가 **same-site가 아닌 cross-site 관계**였음
* cross-site 환경에서 쿠키를 사용하려면 `SameSite=None` 설정이 필요함
* `SameSite=None` 쿠키는 **반드시 `Secure=true`가 요구됨**
* `Secure=true` 쿠키는 **HTTPS 환경에서만 저장 가능**함

### 해결 방법

* refreshToken 쿠키 옵션을 `SameSite=None; Secure=true`로 수정
* 백엔드 서버에 **HTTPS 적용**

  * nginx에서 SSL 설정 추가
  * 80 포트 요청을 443(HTTPS)으로 리다이렉트
  * reverse proxy 환경에서 HTTPS 인식을 위해 `forward-headers-strategy` 설정 추가
* 그럼에도 불구하고 로컬 개발 환경에서는
  Chrome의 **서드파티 쿠키 차단 정책**으로 인해 쿠키 저장이 제한됨

  * Chrome 설정(`chrome://settings/cookies`)에서
    **서드파티 쿠키 허용 사이트에 `http://localhost:5173` 추가**하여 테스트 진행

### 결과

* cross-site 환경에서도 refreshToken 쿠키가 정상적으로 저장 및 전송됨
* `/auth/refresh` 요청 시 쿠키 기반 인증 갱신 동작 확인

### 진행 과정
#### ❌ 1️⃣ `Secure=true + SameSite=None` + `백엔드 HTTP`

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/c743c1f5-c21d-49f3-881f-e5fbd1462d75" />

secure=true인데 백엔드가 `http`라서 브라우저가 Set-Cookie 자체를 거부

------

#### ❌ 2️⃣ `Secure=false + SameSite=Lax` + `백엔드 HTTP`

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/61999ecd-251c-4c9f-8ba0-b9119d1d6f35" />

프론트(localhost) ↔ 백(tritt.o-r.kr) ⇒ cross-site라 불가

- /auth/refresh ⇒ XHR(fetch/axios)
- SameSite=Lax는
  - 최상위 네비게이션만 허용
  - cross-site XHR에서는 Set-Cookie 불가

-----

#### ✅ 3️⃣ `Secure=true + SameSite=None` + `백엔드 HTTPS`

<img width="500" height="" alt="image" src="https://github.com/user-attachments/assets/322749a6-5361-4364-b29b-a69c4e6b5f79" />

- cross-site 쿠키 허용 (SameSite=None)
- HTTPS 충족 (Secure=true)
- 브라우저 정책 요구사항 모두 만족
