### PR TITLE
refactor: `/trip-logs/{id}/likes/status` 인증 정책에 맞게 JWT 필터 정리

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/SecurityConfig.java
@@ -61,7 +61,14 @@ public class SecurityConfig {
                                 "/api/auth/reset-password",
                                 "/api/auth/logout"
                         ).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/trip-logs/**", "/api/trips/**", "/api/search/**").permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/trip-logs/**",
+                                "/api/trips/**",
+                                "/api/search/**"
+                        ).permitAll()
+                        .requestMatchers(HttpMethod.GET,
+                                "/api/trip-logs/*/likes/status"
+                        ).authenticated()
                         .anyRequest().authenticated()
                 )
 

--- a/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ssafy/jjtrip/common/security/JwtAuthenticationFilter.java
@@ -39,38 +39,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             try {
                 authenticate(token);
             } catch (AuthException e) {
-                handleAuthException(request, e);
+                SecurityContextHolder.clearContext();
+                log.debug("Invalid token ignored. uri={}, code={}", request.getRequestURI(), e.getErrorCode());
             }
         }
 
         filterChain.doFilter(request, response);
     }
-
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getServletPath();
-        String method = request.getMethod();
-
-        if (path.equals("/api/auth/login")
-                || path.equals("/api/auth/refresh")
-                || path.equals("/api/auth/signup")
-                || path.startsWith("/api/auth/find-email/")
-                || path.equals("/api/auth/reset-password")
-                || path.equals("/api/auth/logout")) {
-            return true;
-        }
-
-        if ("GET".equals(method) && (
-                path.startsWith("/api/trip-logs/")
-                        || path.startsWith("/api/trips/")
-                        || path.startsWith("/api/search/")
-        )) {
-            return true;
-        }
-
-        return false;
-    }
-
 
     private void authenticate(String token) {
         jwtTokenProvider.validateToken(token);
@@ -81,22 +56,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         Authentication authentication = jwtTokenProvider.getAuthentication(token);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-    }
-
-    private void handleAuthException(HttpServletRequest request, AuthException e) {
-        boolean isTokenExpired = e.getErrorCode() == AuthErrorCode.JWT_TOKEN_EXPIRED;
-        boolean isLogoutRequest = isLogoutRequest(request);
-
-        if (!isTokenExpired || !isLogoutRequest) {
-            throw e;
-        }
-
-        log.debug("만료된 Access Token으로 들어온 로그아웃 요청이 감지되었습니다. 검증 절차를 스킵합니다. URI: {}", request.getRequestURI());
-    }
-
-    private boolean isLogoutRequest(HttpServletRequest request) {
-        String path = request.getServletPath();
-        return path.equals(LOGOUT_URL) || path.equals(LOGOUT_URL + "/");
     }
 
     private String resolveToken(HttpServletRequest request) {


### PR DESCRIPTION
## Issue
<img width="700" height="" alt="image" src="https://github.com/user-attachments/assets/f3652290-fa14-4238-8d42-d22d0884b0ad" />

`/api/trip-logs/{id}/likes/status` 요청에 대해 오류가 났습니다.

## Details

<img width="700" height="" alt="image" src="https://github.com/user-attachments/assets/8355d159-be96-4237-b876-dfa5b5e31d03" />

이 부분 때문에 인증이 필요한 `/api/trip-logs/{id}/likes/status`가 인증 없이 진행되어 userDetails가 설정되지 않아 터지는 것이었습니다.
해당 엔드포인트는 인증 과정을 거치도록 했습니다.

또한 JwtAuthenticationFilter의 불필요했던 shouldNotFilter를 없앴습니다.

토큰이 유효하지 않을 경우 그냥 컨텍스트를 초기화 하고 넘기고, Spring Security가 인증이 필요한 엔드포인트에서 인증된 유저 정보가 없으면 관련 에러를 발생시키게 했습니다.

- GET /trip-logs/{id}/likes/status 는 인증이 필요한 API로 분리
- JWT 필터에서 permitAll 요청에 대한 토큰 오류(만료/위조)를 무시하도록 정책 변경
- 토큰이 유효한 경우에만 SecurityContext에 Authentication 세팅
- 인증이 필요한 요청은 SecurityConfig의 authenticated()에서 401 처리하도록 역할 분리