### PR TITLE
feat: 프로필 조회 API에 여행 계획 및 로그 목록 추가

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/trip/mapper/TripMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/mapper/TripMapper.java
@@ -154,4 +154,30 @@ public interface TripMapper {
         WHERE id = #{tripId}
     """)
     int updateLocationSummary(@Param("tripId") Long tripId, @Param("locationSummary") String locationSummary);
+
+    @Select({
+            "<script>",
+            "SELECT id, user_id, trip_status_id, visibility, title, start_date, end_date, created_at, updated_at ",
+            "FROM trip WHERE user_id = #{userId} ",
+            "<if test='statuses != null and statuses.size > 0'>",
+            "AND trip_status_id IN ",
+            "<foreach item='status' collection='statuses' open='(' separator=',' close=')'>",
+            "#{status, typeHandler=com.ssafy.jjtrip.domain.trip.mapper.TripStatusIdTypeHandler}",
+            "</foreach>",
+            "</if>",
+            "ORDER BY created_at DESC",
+            "</script>"
+    })
+    @Results({
+            @Result(property = "id", column = "id"),
+            @Result(property = "userId", column = "user_id"),
+            @Result(property = "status", column = "trip_status_id", javaType = TripStatus.class, typeHandler = TripStatusIdTypeHandler.class),
+            @Result(property = "visibility", column = "visibility", javaType = TripVisibility.class, typeHandler = EnumTypeHandler.class),
+            @Result(property = "title", column = "title"),
+            @Result(property = "startDate", column = "start_date"),
+            @Result(property = "endDate", column = "end_date"),
+            @Result(property = "createdAt", column = "created_at"),
+            @Result(property = "updatedAt", column = "updated_at")
+    })
+    List<Trip> selectByUserIdAndStatuses(@Param("userId") Long userId, @Param("statuses") List<TripStatus> statuses);
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogSummaryDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/dto/TripLogSummaryDto.java
@@ -1,0 +1,12 @@
+package com.ssafy.jjtrip.domain.triplog.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TripLogSummaryDto {
+    private Long logId;
+    private String title;
+    private String thumbnailUrl;
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -4,6 +4,7 @@ import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogFeedResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogImageResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogSummaryDto;
 import com.ssafy.jjtrip.domain.triplog.entity.TripLogComment;
 import org.apache.ibatis.annotations.*;
 
@@ -155,4 +156,11 @@ public interface TripLogMapper {
 
     @Select("SELECT COUNT(*) FROM log_like WHERE log_id = #{logId}")
     int getLikeCount(Long logId);
+
+    @Select("SELECT tl.id AS logId, tl.title, " +
+            "(SELECT tli.image_url FROM log_image tli WHERE tli.log_id = tl.id ORDER BY tli.order_index ASC LIMIT 1) AS thumbnailUrl " +
+            "FROM trip_log tl " +
+            "JOIN trip t ON tl.trip_id = t.id " +
+            "WHERE t.user_id = #{userId}")
+    List<TripLogSummaryDto> findSummariesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/PublicUserProfileResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/PublicUserProfileResponseDto.java
@@ -1,15 +1,17 @@
 package com.ssafy.jjtrip.domain.user.dto.response;
 
+import com.ssafy.jjtrip.domain.trip.dto.TripDetailResponseDto;
+import com.ssafy.jjtrip.domain.trip.dto.TripResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogSummaryDto; // LogSummaryDto -> TripLogSummaryDto
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+
+import java.util.List;
 
 @Getter
-@Setter
 @Builder
 public class PublicUserProfileResponseDto {
     private Long id;
-    // No email
     private String nickname;
     private String profileImageUrl;
     private String bio;
@@ -21,19 +23,7 @@ public class PublicUserProfileResponseDto {
     private Boolean isProfilePublic;
     private int friendsCount;
 
-    public static PublicUserProfileResponseDto from(UserAndProfileDto userAndProfile) {
-        return PublicUserProfileResponseDto.builder()
-                .id(userAndProfile.getId())
-                .nickname(userAndProfile.getNickname())
-                .profileImageUrl(userAndProfile.getProfileImageUrl())
-                .bio(userAndProfile.getBio())
-                .intro(userAndProfile.getIntro())
-                .homeRegionId(userAndProfile.getHomeRegionId())
-                .travelStyleSummary(userAndProfile.getTravelStyleSummary())
-                .travelStyleId(userAndProfile.getTravelStyleId())
-                .profileBannerUrl(userAndProfile.getProfileBannerUrl())
-                .isProfilePublic(userAndProfile.getIsProfilePublic())
-                .friendsCount(userAndProfile.getFriendsCount())
-                .build();
-    }
+    private List<TripResponseDto> tripOverviews;
+    private List<TripDetailResponseDto> completedTripDetails;
+    private List<TripLogSummaryDto> logs;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserProfileResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/response/UserProfileResponseDto.java
@@ -1,11 +1,14 @@
 package com.ssafy.jjtrip.domain.user.dto.response;
 
+import com.ssafy.jjtrip.domain.trip.dto.TripDetailResponseDto;
+import com.ssafy.jjtrip.domain.trip.dto.TripResponseDto;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogSummaryDto; // LogSummaryDto -> TripLogSummaryDto
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter; // Added for deserialization if needed in some contexts
+
+import java.util.List;
 
 @Getter
-@Setter
 @Builder
 public class UserProfileResponseDto {
     private Long id;
@@ -19,22 +22,9 @@ public class UserProfileResponseDto {
     private Long travelStyleId;
     private String profileBannerUrl;
     private Boolean isProfilePublic;
-    private int friendsCount; // Added friendsCount
+    private int friendsCount;
 
-    public static UserProfileResponseDto from(UserAndProfileDto userAndProfile) {
-        return UserProfileResponseDto.builder()
-                .id(userAndProfile.getId())
-                .email(userAndProfile.getEmail())
-                .nickname(userAndProfile.getNickname())
-                .profileImageUrl(userAndProfile.getProfileImageUrl())
-                .bio(userAndProfile.getBio())
-                .intro(userAndProfile.getIntro())
-                .homeRegionId(userAndProfile.getHomeRegionId())
-                .travelStyleSummary(userAndProfile.getTravelStyleSummary())
-                .travelStyleId(userAndProfile.getTravelStyleId())
-                .profileBannerUrl(userAndProfile.getProfileBannerUrl())
-                .isProfilePublic(userAndProfile.getIsProfilePublic())
-                .friendsCount(userAndProfile.getFriendsCount()) // Map friendsCount
-                .build();
-    }
+    private List<TripResponseDto> tripOverviews;
+    private List<TripDetailResponseDto> completedTripDetails;
+    private List<TripLogSummaryDto> logs;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/service/UserService.java
@@ -5,6 +5,13 @@ import com.ssafy.jjtrip.common.s3.S3Service;
 import com.ssafy.jjtrip.common.util.EmailMasker;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.auth.exception.AuthException;
+import com.ssafy.jjtrip.domain.trip.dto.TripDetailResponseDto;
+import com.ssafy.jjtrip.domain.trip.dto.TripResponseDto;
+import com.ssafy.jjtrip.domain.trip.entity.Trip;
+import com.ssafy.jjtrip.domain.trip.entity.TripStatus;
+import com.ssafy.jjtrip.domain.trip.mapper.TripMapper;
+import com.ssafy.jjtrip.domain.triplog.dto.TripLogSummaryDto;
+import com.ssafy.jjtrip.domain.triplog.mapper.TripLogMapper;
 import com.ssafy.jjtrip.domain.user.dto.request.UpdateUserRequestDto;
 import com.ssafy.jjtrip.domain.user.dto.response.PublicUserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.UserAndProfileDto;
@@ -19,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.util.StringUtils;
 
 import java.security.SecureRandom;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,25 +39,102 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final EmailService emailService;
     private final S3Service s3Service;
-    
+    private final TripMapper tripMapper;
+    private final TripLogMapper tripLogMapper;
+
     public UserProfileResponseDto getUserProfile(Long userId) {
         UserAndProfileDto userAndProfile = userMapper.findUserAndProfileById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
-        return mapToUserProfileResponseDto(userAndProfile);
+        List<TripStatus> allStatuses = List.of(TripStatus.DRAFT, TripStatus.PLANNED, TripStatus.COMPLETED);
+        List<Trip> allTrips = tripMapper.selectByUserIdAndStatuses(userId, allStatuses);
+
+        List<TripResponseDto> tripOverviews = mapToTripResponseDtos(allTrips, userId);
+        List<TripDetailResponseDto> completedTripDetails = mapToTripDetailResponseDtos(allTrips);
+        List<TripLogSummaryDto> logs = tripLogMapper.findSummariesByUserId(userId);
+
+        return UserProfileResponseDto.builder()
+                .id(userAndProfile.getId())
+                .email(userAndProfile.getEmail())
+                .nickname(userAndProfile.getNickname())
+                .profileImageUrl(userAndProfile.getProfileImageUrl())
+                .bio(userAndProfile.getBio())
+                .intro(userAndProfile.getIntro())
+                .homeRegionId(userAndProfile.getHomeRegionId())
+                .travelStyleSummary(userAndProfile.getTravelStyleSummary())
+                .travelStyleId(userAndProfile.getTravelStyleId())
+                .profileBannerUrl(userAndProfile.getProfileBannerUrl())
+                .isProfilePublic(userAndProfile.getIsProfilePublic())
+                .friendsCount(userAndProfile.getFriendsCount())
+                .tripOverviews(tripOverviews)
+                .completedTripDetails(completedTripDetails)
+                .logs(logs)
+                .build();
     }
-    
+
     public PublicUserProfileResponseDto getPublicUserProfile(Long userId) {
         UserAndProfileDto userAndProfile = userMapper.findUserAndProfileById(userId)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
 
-        return PublicUserProfileResponseDto.from(userAndProfile);
+        List<TripStatus> publicStatuses = List.of(TripStatus.PLANNED, TripStatus.COMPLETED);
+        List<Trip> publicTrips = tripMapper.selectByUserIdAndStatuses(userId, publicStatuses);
+
+        List<TripResponseDto> tripOverviews = mapToTripResponseDtos(publicTrips, userId);
+        List<TripDetailResponseDto> completedTripDetails = mapToTripDetailResponseDtos(publicTrips);
+        List<TripLogSummaryDto> logs = tripLogMapper.findSummariesByUserId(userId);
+
+        return PublicUserProfileResponseDto.builder()
+                .id(userAndProfile.getId())
+                .nickname(userAndProfile.getNickname())
+                .profileImageUrl(userAndProfile.getProfileImageUrl())
+                .bio(userAndProfile.getBio())
+                .intro(userAndProfile.getIntro())
+                .homeRegionId(userAndProfile.getHomeRegionId())
+                .travelStyleSummary(userAndProfile.getTravelStyleSummary())
+                .travelStyleId(userAndProfile.getTravelStyleId())
+                .profileBannerUrl(userAndProfile.getProfileBannerUrl())
+                .isProfilePublic(userAndProfile.getIsProfilePublic())
+                .friendsCount(userAndProfile.getFriendsCount())
+                .tripOverviews(tripOverviews)
+                .completedTripDetails(completedTripDetails)
+                .logs(logs)
+                .build();
+    }
+
+    private List<TripResponseDto> mapToTripResponseDtos(List<Trip> trips, Long userId) {
+        return trips.stream()
+                .map(trip -> {
+                    boolean isOwner = trip.getUserId().equals(userId);
+                    int spots = tripMapper.countTripItemsByTripId(trip.getId());
+                    List<String> tags = Collections.emptyList();
+                    List<TripResponseDto.SpotPreviewDto> spotPreviews = tripMapper.selectSpotPreviewNamesByTripId(trip.getId())
+                            .stream()
+                            .map(TripResponseDto.SpotPreviewDto::new)
+                            .collect(Collectors.toList());
+                    return TripResponseDto.from(trip, isOwner, spots, tags, spotPreviews);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<TripDetailResponseDto> mapToTripDetailResponseDtos(List<Trip> trips) {
+        return trips.stream()
+                .filter(trip -> trip.getStatus() == TripStatus.COMPLETED)
+                .map(trip -> {
+                    trip.setTripItems(tripMapper.selectItemsWithSpotsByTripId(trip.getId()));
+                    return TripDetailResponseDto.from(trip);
+                })
+                .collect(Collectors.toList());
     }
 
     public List<PublicUserProfileResponseDto> getFriendsList(Long userId) {
         List<UserAndProfileDto> friends = userMapper.findFriendsByUserId(userId);
         return friends.stream()
-                .map(PublicUserProfileResponseDto::from)
+                .map(friend -> PublicUserProfileResponseDto.builder()
+                        .id(friend.getId())
+                        .nickname(friend.getNickname())
+                        .profileImageUrl(friend.getProfileImageUrl())
+                        .bio(friend.getBio())
+                        .build())
                 .collect(Collectors.toList());
     }
 
@@ -86,13 +171,9 @@ public class UserService {
                 .orElseThrow(() -> new AuthException(AuthErrorCode.USER_NOT_FOUND));
         String oldImageUrl = user.getProfileImageUrl();
 
-        // S3에 새 이미지 업로드
         String newImageUrl = s3Service.uploadProfileImage(profileImage);
-
-        // DB에 새 이미지 URL 업데이트
         userMapper.updateProfileImageUrl(userId, newImageUrl);
 
-        // S3에서 기존 이미지 삭제 (존재하는 경우)
         if (StringUtils.hasText(oldImageUrl)) {
             s3Service.deleteImage(oldImageUrl);
         }
@@ -110,23 +191,6 @@ public class UserService {
             s3Service.deleteImage(imageUrl);
             userMapper.deleteProfileImageUrl(userId);
         }
-    }
-
-    private UserProfileResponseDto mapToUserProfileResponseDto(UserAndProfileDto userAndProfile) {
-        return UserProfileResponseDto.builder()
-                .id(userAndProfile.getId())
-                .email(userAndProfile.getEmail())
-                .nickname(userAndProfile.getNickname())
-                .profileImageUrl(userAndProfile.getProfileImageUrl())
-                .bio(userAndProfile.getBio())
-                .intro(userAndProfile.getIntro())
-                .homeRegionId(userAndProfile.getHomeRegionId())
-                .travelStyleSummary(userAndProfile.getTravelStyleSummary())
-                .travelStyleId(userAndProfile.getTravelStyleId())
-                .profileBannerUrl(userAndProfile.getProfileBannerUrl())
-                .isProfilePublic(userAndProfile.getIsProfilePublic())
-                .friendsCount(userAndProfile.getFriendsCount()) // Pass friendsCount
-                .build();
     }
     
     private String generateTemporaryPassword() {


### PR DESCRIPTION
## Issue
- #59 

## Details
이 PR은 **LOG 페이지**의 여행 일기/계획 탭, 지도 위젯, 달력 위젯에 **데이터를 렌더링하기 위해 DTO 구조를 개편**했습니다.
**매퍼에 변경된 DTO에 맞는 데이터 조회를 위한 함수를 추가**하고, **서비스 레이어의 builder 구성 요소를 수정**했습니다.

### ✔️ 주요 변경 사항
- `UserProfileResponseDto`, `PublicUserProfileResponseDto`에 **여행 계획 목록(`tripOverviews`), 완료된 여행의 상세 정보(`completedTripDetails`), 여행 일기 목록(`logs`) 필드 추가**
- 각 필드를 List로 담기 위한 **새로운 DTO 생성**
- DTO 필드 변경에 따른 **`UserService`에서의 작업 변경**
- **`TripMapper`, `TripLogMapper`에 새로운 함수(`selectByUserIdAndStatuses`, `findSummariesByUserId`) 추가**

---

### 📘 API 명세
- GET `/api/users/me`
  - 내 프로필 및 여행 정보를 조회합니다.
  - `tripOverviews`, `completedTripDetails`, `logs` 필드가 추가되었습니다.
- POST `/api/users/{userId}/profile`
  - 타인의 프로필 및 여행 정보를 조회합니다.
  - `tripOverviews`, `completedTripDetails`, `logs` 필드가 추가되었습니다.

---

### 🚧 특이사항
현재 **LogView.vue**에서는 '내 정보 조회' 시, `/users/me` 엔드포인트를 사용하지 않고 **`/users/${loggedInUser.value.id}/profile` 엔드포인트로 접근**하고 있습니다.
**목적에 맞는 경로로 접근할 수 있도록 수정해야 합니다.**

---

### 📅 향후 계획
- 프론트엔드에서의 내 프로필 조회 요청 경로를 `/api/users/me`로 수정합니다.