### PR TITLE
feat: 닉네임/비밀번호 정책 추가

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/auth/dto/SignupRequestDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/dto/SignupRequestDto.java
@@ -2,6 +2,7 @@ package com.ssafy.jjtrip.domain.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignupRequestDto(
@@ -11,10 +12,11 @@ public record SignupRequestDto(
         String email,
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다.")
-        @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$", message = "비밀번호는 8자 이상이어야 하며, 영어 대문자, 소문자, 숫자, 특수문자를 모두 포함해야 합니다.")
         String password,
 
         @NotBlank(message = "닉네임은 필수 입력값입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "닉네임은 영어, 숫자, 언더스코어(_)만 사용 가능합니다.")
         String nickname
 ) {
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import com.ssafy.jjtrip.domain.user.entity.Role;
 import com.ssafy.jjtrip.domain.user.entity.User;
 import com.ssafy.jjtrip.domain.user.entity.UserStatus;
 import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -29,7 +28,6 @@ public class AuthService {
 
     private static final String REDIS_REFRESH_TOKEN_PREFIX = "RefreshToken:";
     private static final String REDIS_BLACKLIST_PREFIX = "BlackList:";
-    private static final String PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenProvider jwtTokenProvider;
@@ -69,7 +67,6 @@ public class AuthService {
 
     @Transactional
     public void signup(SignupRequestDto signupRequestDto) {
-        validatePassword(signupRequestDto.password());
         validateDuplicateEmail(signupRequestDto.email());
         validateDuplicateNickname(signupRequestDto.nickname());
         User user = buildNewUser(signupRequestDto);
@@ -108,12 +105,6 @@ public class AuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(authentication);
         String refreshToken = jwtTokenProvider.generateRefreshToken(authentication);
         return new TokenInfo(accessToken, refreshToken, accessTokenExpireTimeMs);
-    }
-
-    private void validatePassword(String password) {
-        if (!Pattern.matches(PASSWORD_PATTERN, password)) {
-            throw new AuthException(AuthErrorCode.INVALID_PASSWORD_FORMAT);
-        }
     }
 
     private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import com.ssafy.jjtrip.domain.user.dto.response.PublicUserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.ProfileImageUpdateResponseDto;
 import com.ssafy.jjtrip.domain.user.dto.response.UserProfileResponseDto;
 import com.ssafy.jjtrip.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,7 +37,7 @@ public class UserController {
     }
 
     @PatchMapping("/me")
-    public ResponseEntity<Void> updateUserProfile(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UpdateUserRequestDto updateUserRequestDto) {
+    public ResponseEntity<Void> updateUserProfile(@AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody UpdateUserRequestDto updateUserRequestDto) {
         userService.updateUserProfile(userDetails.getUser().getId(), updateUserRequestDto);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/ssafy/jjtrip/domain/user/dto/request/UpdateUserRequestDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/dto/request/UpdateUserRequestDto.java
@@ -1,11 +1,13 @@
 package com.ssafy.jjtrip.domain.user.dto.request;
 
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class UpdateUserRequestDto {
+    @Pattern(regexp = "^[a-zA-Z0-9_]+$", message = "닉네임은 영어, 숫자, 언더스코어(_)만 사용 가능합니다.")
     private String nickname;
     private String bio;
 }


### PR DESCRIPTION
## Issue
- #56 
- #57 

## Details
이 PR은 **닉네임에 작명 정책을 추가**하고, **비밀번호 유효성 검사 시점을 변경**했습니다.

### ✔️ 주요 변경 사항
**닉네임**은 회원가입, **닉네임 변경 시 영문, 숫자, 언더바로만 구성**할 수 있고,
**비밀번호**는 기존에 Service 레벨에서 유효성 검사를 실시했으나, **DTO 레벨에서 수행**하도록 변경함에 따라 Service 레이어는 비즈니스 로직만 수행할 수 있도록 개선했습니다.

---

### 📘 API 명세
- POST `/api/auth/signup`
  - **유효하지 않은 닉네임으로 회원가입 (`400 Bad Request`)**
`
{
    "email": "invalid@nickname.com",
    "password": "Password123!",
    "nickname": "testuser-2!"
}
`
  - **유효하지 않은 비밀번호로 회원가입 (`400 Bad Request`)**
`
{
    "email": "invalid@password.com",
    "password": "password123",
    "nickname": "_testuser"
}
`
  - **유효한 회원가입 (`201 Created`)**
`
{
    "email": "valid@test.com",
    "password": "Password123!",
    "nickname": "_testuser"
}
`

---

### 🚧 특이사항
현재 UI에서는 **정책을 위반하는 입력값에 대해 별도의 안내가 없습니다.**
닉네임과 비밀번호 정책을 준수하는 입력값인지 **실시간 피드백을 줄 수 있도록 하여 UX를 개선해야 합니다.**

---

### 📅 향후 계획
- **프론트엔드에서 닉네임/비밀번호 정책 준수 여부를 실시간으로 사용자에게 안내할 수 있도록** 합니다.