### PR TITLE
feat: hot place top 10 api 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/common/config/CacheConfig.java
+++ b/src/main/java/com/ssafy/jjtrip/common/config/CacheConfig.java
@@ -1,0 +1,44 @@
+package com.ssafy.jjtrip.common.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableCaching
+@EnableScheduling
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(60)) // 기본 TTL
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
@@ -1,0 +1,29 @@
+package com.ssafy.jjtrip.domain.spot.controller;
+
+import com.ssafy.jjtrip.domain.spot.dto.SpotResponseDto;
+import com.ssafy.jjtrip.domain.spot.entity.Spot;
+import com.ssafy.jjtrip.domain.spot.service.SpotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/spots")
+@RequiredArgsConstructor
+public class SpotController {
+
+    private final SpotService spotService;
+
+    @GetMapping("/hot")
+    public ResponseEntity<List<SpotResponseDto>> getHotPlaces() {
+        List<Spot> hotPlaces = spotService.getTop10HotPlaces();
+        List<SpotResponseDto> response = hotPlaces.stream()
+                .map(SpotResponseDto::from)
+                .toList();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/mapper/SpotMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/mapper/SpotMapper.java
@@ -1,6 +1,7 @@
 package com.ssafy.jjtrip.domain.spot.mapper;
 
 import com.ssafy.jjtrip.domain.spot.entity.Spot;
+import java.util.List;
 import java.util.Optional;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
@@ -26,4 +27,15 @@ public interface SpotMapper {
         )
     """)
     boolean existsById(@Param("spotId") Long spotId);
+
+    @Select("""
+        SELECT s.id, s.kakao_place_id, s.name, s.address, s.category, s.lat, s.lng, 
+               s.place_url, s.thumbnail_url, s.review_count, s.average_rating, s.created_at
+        FROM spot s
+        JOIN trip_item ti ON s.id = ti.spot_id
+        GROUP BY s.id
+        ORDER BY COUNT(ti.id) DESC
+        LIMIT 10
+    """)
+    List<Spot> findTop10MostAdded();
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
@@ -5,12 +5,19 @@ import com.ssafy.jjtrip.domain.spot.exception.SpotErrorCode;
 import com.ssafy.jjtrip.domain.spot.exception.SpotException;
 import com.ssafy.jjtrip.domain.spot.mapper.SpotMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Scheduled;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class SpotService {
 
     private final SpotMapper spotMapper;
@@ -27,5 +34,17 @@ public class SpotService {
         if (!spotMapper.existsById(spotId)) {
             throw new SpotException(SpotErrorCode.SPOT_NOT_FOUND);
         }
+    }
+
+    @Transactional(readOnly = true)
+    @Cacheable(value = "hotPlaces", key = "'top10'")
+    public List<Spot> getTop10HotPlaces() {
+        return spotMapper.findTop10MostAdded();
+    }
+
+    @Scheduled(fixedRateString = "${app.cache.hot-place-refresh-rate:600000}")
+    @CacheEvict(value = "hotPlaces", allEntries = true)
+    public void evictHotPlacesCache() {
+        log.info("Hot Place 캐시가 갱신되었습니다.");
     }
 }


### PR DESCRIPTION
## Issue
- close #51 

## Details
`GET /api/spots/hot`을 구현했습니다.

Logic:
- trip_item 테이블을 집계하여, 사용자들의 여행 계획에 가장 많이 포함된 장소 Top 10을 선정.

Performance (Caching):
- Spring Cache + Redis(설정 기반)를 도입하여 성능 최적화.
- 설정된 시간(ex: 10분)마다 캐시를 갱신(`@Scheduled`)하여 DB 부하를 차단하고 0ms 수준의 응답 속도 보장.
- CacheConfig에 JSON Serializer를 적용하여 Serializable 인터페이스 구현 없이도 깔끔하게 객체 캐싱 구현.

+) 현재 썸네일, 운영 시간은 카카오맵에서 제공되지 않습니다. google maps api를 적용해보거나 다른 방식으로 관련 정보 매핑이 필요할 것 같습니다.