### PR TITLE
refactor: 로그 이미지 url을 파싱하여 db에 저장하도록 변경

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
@@ -8,7 +8,6 @@ import com.ssafy.jjtrip.domain.triplog.dto.ImageUploadRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCommentRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCreateRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogCreateResponseDto;
-import com.ssafy.jjtrip.domain.triplog.dto.TripLogCreateResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogFeedResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogLikeResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.TripLogUpdateRequestDto;

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -34,6 +34,9 @@ public interface TripLogMapper {
             "VALUES (#{logId}, #{userId}, #{imageUrl}, #{orderIndex}, #{imageRefKey})")
     void insertTripLogImage(LogImageInsertInfo imageInfo);
 
+    @Delete("DELETE FROM log_image WHERE log_id = #{logId}")
+    void deleteLogImages(Long logId);
+
     @Select("SELECT EXISTS(SELECT 1 FROM trip_log WHERE trip_id = #{tripId})")
     boolean existsByTripId(Long tripId);
 

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -53,6 +53,8 @@ public class TripLogService {
                 .build();
 
         tripLogMapper.insertTripLog(tripLog);
+        processAndSaveImages(tripLog.getId(), userId, requestDto.content());
+
         return new TripLogCreateResponseDto(tripLog.getId());
     }
 
@@ -119,6 +121,31 @@ public class TripLogService {
                 .build();
 
         tripLogMapper.updateTripLog(tripLog);
+
+        if (requestDto.content() != null) {
+            tripLogMapper.deleteLogImages(logId);
+            processAndSaveImages(logId, userId, requestDto.content());
+        }
+    }
+
+    private void processAndSaveImages(Long logId, Long userId, String content) {
+        if (content == null || content.isBlank()) {
+            return;
+        }
+
+        // Markdown Image Pattern: ![alt](url)
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("!\\[.*?\\]\\((.*?)\\)");
+        java.util.regex.Matcher matcher = pattern.matcher(content);
+
+        int orderIndex = 0;
+        while (matcher.find()) {
+            String imageUrl = matcher.group(1);
+            String imageRefKey = "img_" + orderIndex; 
+            
+            tripLogMapper.insertTripLogImage(new TripLogMapper.LogImageInsertInfo(
+                    logId, userId, imageUrl, orderIndex++, imageRefKey
+            ));
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## Issue
- close #74 

## Details
이슈를 해결하기 위해 로그 생성, 업데이트 시 content에 있는 `![alt](url)` 형식을 파싱하여 db에 로그별 이미지 url들을 모아놓을 수 있게 했습니다.