### PR TITLE
feat: 받은/보낸 친구 신청 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/friends")
+@RequestMapping("/friends")
 @RequiredArgsConstructor
 public class FriendController {
 

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
@@ -2,19 +2,23 @@ package com.ssafy.jjtrip.domain.friend.controller;
 
 import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.domain.friend.dto.request.FriendRequestRequestDto;
+import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
 import com.ssafy.jjtrip.domain.friend.service.FriendService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
-@RequestMapping("/friends")
+@RequestMapping("/api/friends")
 @RequiredArgsConstructor
 public class FriendController {
 
@@ -28,5 +32,23 @@ public class FriendController {
         Long requesterId = userDetails.getUser().getId();
         friendService.sendRequest(requesterId, requestDto.getReceiverId());
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping("/requests/received")
+    public ResponseEntity<List<FriendRequestResponseDto>> getReceivedRequests(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<FriendRequestResponseDto> receivedRequests = friendService.getReceivedRequests(userId);
+        return ResponseEntity.ok(receivedRequests);
+    }
+
+    @GetMapping("/requests/sent")
+    public ResponseEntity<List<FriendRequestResponseDto>> getSentRequests(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<FriendRequestResponseDto> sentRequests = friendService.getSentRequests(userId);
+        return ResponseEntity.ok(sentRequests);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
@@ -1,10 +1,12 @@
 package com.ssafy.jjtrip.domain.friend.mapper;
 
+import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
 import com.ssafy.jjtrip.domain.friend.entity.Friendship;
 import org.apache.ibatis.annotations.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -24,14 +26,47 @@ public interface FriendMapper {
             "WHERE (requester_id = #{requesterId} AND receiver_id = #{receiverId}) OR " +
             "(requester_id = #{receiverId} AND receiver_id = #{requesterId})")
     Optional<FriendRequest> findRequestByUsers(@Param("requesterId") Long requesterId, @Param("receiverId") Long receiverId);
-    
+
     // 이미 친구인지 검증용
     @Select("SELECT * FROM friendship WHERE user_id_a = #{userIdA} AND user_id_b = #{userIdB}")
     Optional<Friendship> findFriendshipByUsers(@Param("userIdA") Long userIdA, @Param("userIdB") Long userIdB);
 
     // 3. ID로 친구 요청 조회
+
+
     // 4. 받은 친구 요청 목록 조회
+    @Select("SELECT fr.id as requestId, fr.status, fr.created_at as createdAt, " +
+            "u.id as userId, u.nickname, u.profile_image_url as profileImageUrl " +
+            "FROM friend_request fr " +
+            "JOIN user u ON fr.requester_id = u.id " +
+            "WHERE fr.receiver_id = #{userId} AND fr.status = 'PENDING'")
+    @Results({
+            @Result(property = "requestId", column = "requestId"),
+            @Result(property = "status", column = "status"),
+            @Result(property = "createdAt", column = "createdAt"),
+            @Result(property = "user.userId", column = "userId"),
+            @Result(property = "user.nickname", column = "nickname"),
+            @Result(property = "user.profileImageUrl", column = "profileImageUrl")
+    })
+    List<FriendRequestResponseDto> findReceivedRequestsByUserId(@Param("userId") Long userId);
+
+
     // 5. 보낸 친구 요청 목록 조회
+    @Select("SELECT fr.id as requestId, fr.status, fr.created_at as createdAt, " +
+            "u.id as userId, u.nickname, u.profile_image_url as profileImageUrl " +
+            "FROM friend_request fr " +
+            "JOIN user u ON fr.receiver_id = u.id " +
+            "WHERE fr.requester_id = #{userId}")
+    @Results({
+            @Result(property = "requestId", column = "requestId"),
+            @Result(property = "status", column = "status"),
+            @Result(property = "createdAt", column = "createdAt"),
+            @Result(property = "user.userId", column = "userId"),
+            @Result(property = "user.nickname", column = "nickname"),
+            @Result(property = "user.profileImageUrl", column = "profileImageUrl")
+    })
+    List<FriendRequestResponseDto> findSentRequestsByUserId(@Param("userId") Long userId);
+    
     // 6. 친구 요청 삭제
     // 7. 친구 관계 생성
     // 8. 친구 관계 삭제

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -1,17 +1,18 @@
 package com.ssafy.jjtrip.domain.friend.service;
 
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
+import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
 import com.ssafy.jjtrip.domain.friend.exception.FriendErrorCode;
 import com.ssafy.jjtrip.domain.friend.exception.FriendException;
 import com.ssafy.jjtrip.domain.friend.mapper.FriendMapper;
-import com.ssafy.jjtrip.domain.user.entity.User;
 import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -54,5 +55,13 @@ public class FriendService {
                 .status(FriendRequestStatus.PENDING)
                 .build();
         friendMapper.saveRequest(friendRequest);
+    }
+
+    public List<FriendRequestResponseDto> getReceivedRequests(Long userId) {
+        return friendMapper.findReceivedRequestsByUserId(userId);
+    }
+
+    public List<FriendRequestResponseDto> getSentRequests(Long userId) {
+        return friendMapper.findSentRequestsByUserId(userId);
     }
 }


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 **받은/보낸 친구 신청 목록을 조회하는 API**를 구현했습니다.

### ✔️ 주요 변경 사항
`FriendController`에 `getReceivedRequests`, `getSentRequests` 메서드를 추가했습니다.
친구 신청 목록은 로그인된 사용자 본인만 열람할 수 있어야 하므로 `@AuthenticationPrincipal` 어노테이션을 통해 인증 절차를 거칩니다.

`FriendService`는 `FriendMapper`의 `findReceivedRequestsByUserId`, `findSentRequestsByUserId` 메서드를 호출합니다.

---

### 📘 API 명세
- GET `/api/friends/requests/received`
  - **성공 (`200 OK`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

- GET `/api/friends/requests/sent`
  - **성공 (`200 OK`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

---

### 📅 향후 계획
- 친구 기능을 위한 **나머지 API를 개발**합니다.
  - 친구 신청 수락
  - 친구 신청 거절
  - 보낸 친구 신청 취소
  - 친구 목록 조회
  - 친구 삭제
  - 친구 피드 조회