### PR TITLE
feat: Trip, TripLog CUD - Elasticsearch 동기화 로직 구현 및 날짜 정규화

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/search/dto/TripLogSearchDoc.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/dto/TripLogSearchDoc.java
@@ -1,14 +1,18 @@
 package com.ssafy.jjtrip.domain.search.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Field;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+
 import java.util.List;
 
 @Document(indexName = "trit_trip_log")
 public record TripLogSearchDoc(
+    @Id
     @Field(name = "log_id")
     @JsonProperty("log_id") Long logId,
 
@@ -27,14 +31,14 @@ public record TripLogSearchDoc(
     @Field(name = "trip_location_summary")
     @JsonProperty("trip_location_summary") String tripLocationSummary,
 
-    @Field(name = "trip_start_date")
-    @JsonProperty("trip_start_date") LocalDate tripStartDate,
+    @Field(name = "trip_start_date", type = FieldType.Keyword)
+    @JsonProperty("trip_start_date") String tripStartDate,
 
-    @Field(name = "trip_end_date")
-    @JsonProperty("trip_end_date") LocalDate tripEndDate,
+    @Field(name = "trip_end_date", type = FieldType.Keyword)
+    @JsonProperty("trip_end_date") String tripEndDate,
 
-    @Field(name = "created_at")
-    @JsonProperty("created_at") LocalDateTime createdAt,
+    @Field(name = "created_at", type = FieldType.Keyword)
+    @JsonProperty("created_at") String createdAt,
 
     @Field(name = "image_urls")
     @JsonProperty("image_urls") List<String> imageUrls

--- a/src/main/java/com/ssafy/jjtrip/domain/search/dto/TripSearchDoc.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/dto/TripSearchDoc.java
@@ -1,14 +1,17 @@
 package com.ssafy.jjtrip.domain.search.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.DateFormat;
 import org.springframework.data.elasticsearch.annotations.Field;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
 import java.util.List;
 
 @Document(indexName = "trit_trip")
 public record TripSearchDoc(
+    @Id
     @Field(name = "trip_id")
     @JsonProperty("trip_id") Long tripId,
 
@@ -21,14 +24,14 @@ public record TripSearchDoc(
     @Field(name = "location_summary")
     @JsonProperty("location_summary") String locationSummary,
 
-    @Field(name = "start_date")
-    @JsonProperty("start_date") LocalDate startDate,
+    @Field(name = "start_date", type = FieldType.Keyword)
+    @JsonProperty("start_date") String startDate,
 
-    @Field(name = "end_date")
-    @JsonProperty("end_date") LocalDate endDate,
+    @Field(name = "end_date", type = FieldType.Keyword)
+    @JsonProperty("end_date") String endDate,
 
-    @Field(name = "created_at")
-    @JsonProperty("created_at") LocalDateTime createdAt,
+    @Field(name = "created_at", type = FieldType.Keyword)
+    @JsonProperty("created_at") String createdAt,
 
     @Field(name = "spot_names")
     @JsonProperty("spot_names") List<String> spotNames,

--- a/src/main/java/com/ssafy/jjtrip/domain/search/service/TripLogSearchService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/service/TripLogSearchService.java
@@ -1,17 +1,23 @@
 package com.ssafy.jjtrip.domain.search.service;
 
 import com.ssafy.jjtrip.domain.search.dto.TripLogSearchDoc;
+import com.ssafy.jjtrip.domain.search.util.SearchUtil;
+import com.ssafy.jjtrip.domain.trip.entity.Trip;
+import com.ssafy.jjtrip.domain.trip.entity.TripVisibility;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLog;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLogVisibility;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.stereotype.Service;
-import java.util.List;
 
-@RequiredArgsConstructor
+@Slf4j
 @Service
-@lombok.extern.slf4j.Slf4j
+@RequiredArgsConstructor
 public class TripLogSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
@@ -50,7 +56,7 @@ public class TripLogSearchService {
             "minimum_should_match": 0
           }
         }
-        """.formatted(escapeJson(keyword), escapeJson(keyword));
+        """.formatted(SearchUtil.escapeJson(keyword), SearchUtil.escapeJson(keyword));
 
         Query query = new StringQuery(queryString);
         return elasticsearchOperations.search(query, TripLogSearchDoc.class)
@@ -68,35 +74,16 @@ public class TripLogSearchService {
                 doc.title(),
                 doc.content(),
                 doc.tripLocationSummary(),
-                normalizeDate(doc.tripStartDate(), false),
-                normalizeDate(doc.tripEndDate(), false),
-                normalizeDate(doc.createdAt(), true),
+                SearchUtil.normalizeDate(doc.tripStartDate(), false),
+                SearchUtil.normalizeDate(doc.tripEndDate(), false),
+                SearchUtil.normalizeDate(doc.createdAt(), true),
                 doc.imageUrls()
         );
     }
 
-    private String normalizeDate(String value, boolean isDateTime) {
-        if (value == null) return null;
-        if (value.matches("^\\d+$")) {
-            try {
-                long millis = Long.parseLong(value);
-                java.time.ZonedDateTime zdt = java.time.Instant.ofEpochMilli(millis)
-                        .atZone(java.time.ZoneId.systemDefault());
-                if (isDateTime) {
-                    return zdt.toLocalDateTime().toString();
-                } else {
-                    return zdt.toLocalDate().toString();
-                }
-            } catch (Exception e) {
-                return value;
-            }
-        }
-        return value;
-    }
-
-    public void saveTripLog(com.ssafy.jjtrip.domain.triplog.entity.TripLog tripLog, com.ssafy.jjtrip.domain.trip.entity.Trip trip, List<String> imageUrls) {
-        if (tripLog.getVisibility() != com.ssafy.jjtrip.domain.triplog.entity.TripLogVisibility.PUBLIC ||
-            trip.getVisibility() != com.ssafy.jjtrip.domain.trip.entity.TripVisibility.PUBLIC) {
+    public void saveTripLog(TripLog tripLog, Trip trip, List<String> imageUrls) {
+        if (tripLog.getVisibility() != TripLogVisibility.PUBLIC ||
+            trip.getVisibility() != TripVisibility.PUBLIC) {
             deleteTripLog(tripLog.getId());
             return;
         }
@@ -123,30 +110,5 @@ public class TripLogSearchService {
         log.info("Deleting trip log from ES: {}", logId);
         elasticsearchOperations.delete(String.valueOf(logId), TripLogSearchDoc.class);
         log.info("Deleted trip log from ES: {}", logId);
-    }
-
-    private static String escapeJson(String s) {
-        if (s == null) return "";
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '"' -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\b' -> sb.append("\\b");
-                case '\f' -> sb.append("\\f");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> {
-                    if (c < ' ') {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/search/service/TripLogSearchService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/service/TripLogSearchService.java
@@ -11,6 +11,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Service
+@lombok.extern.slf4j.Slf4j
 public class TripLogSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
@@ -53,7 +54,75 @@ public class TripLogSearchService {
 
         Query query = new StringQuery(queryString);
         return elasticsearchOperations.search(query, TripLogSearchDoc.class)
-                .stream().map(SearchHit::getContent).toList();
+                .stream()
+                .map(SearchHit::getContent)
+                .map(this::normalizeDoc)
+                .toList();
+    }
+
+    private TripLogSearchDoc normalizeDoc(TripLogSearchDoc doc) {
+        return new TripLogSearchDoc(
+                doc.logId(),
+                doc.tripId(),
+                doc.userId(),
+                doc.title(),
+                doc.content(),
+                doc.tripLocationSummary(),
+                normalizeDate(doc.tripStartDate(), false),
+                normalizeDate(doc.tripEndDate(), false),
+                normalizeDate(doc.createdAt(), true),
+                doc.imageUrls()
+        );
+    }
+
+    private String normalizeDate(String value, boolean isDateTime) {
+        if (value == null) return null;
+        if (value.matches("^\\d+$")) {
+            try {
+                long millis = Long.parseLong(value);
+                java.time.ZonedDateTime zdt = java.time.Instant.ofEpochMilli(millis)
+                        .atZone(java.time.ZoneId.systemDefault());
+                if (isDateTime) {
+                    return zdt.toLocalDateTime().toString();
+                } else {
+                    return zdt.toLocalDate().toString();
+                }
+            } catch (Exception e) {
+                return value;
+            }
+        }
+        return value;
+    }
+
+    public void saveTripLog(com.ssafy.jjtrip.domain.triplog.entity.TripLog tripLog, com.ssafy.jjtrip.domain.trip.entity.Trip trip, List<String> imageUrls) {
+        if (tripLog.getVisibility() != com.ssafy.jjtrip.domain.triplog.entity.TripLogVisibility.PUBLIC ||
+            trip.getVisibility() != com.ssafy.jjtrip.domain.trip.entity.TripVisibility.PUBLIC) {
+            deleteTripLog(tripLog.getId());
+            return;
+        }
+
+        TripLogSearchDoc doc = new TripLogSearchDoc(
+                tripLog.getId(),
+                trip.getId(),
+                trip.getUserId(),
+                tripLog.getTitle(),
+                tripLog.getContent(),
+                trip.getLocationSummary(),
+                trip.getStartDate() != null ? trip.getStartDate().toString() : null,
+                trip.getEndDate() != null ? trip.getEndDate().toString() : null,
+                tripLog.getCreatedAt() != null ? tripLog.getCreatedAt().toString() : null,
+                imageUrls
+        );
+
+        log.info("Saving trip log to ES: {}", tripLog.getId());
+        elasticsearchOperations.save(doc);
+        log.info("Saved trip log to ES: {}", tripLog.getId());
+    }
+
+    public void deleteTripLog(Long logId) {
+        log.info("Deleting trip log from ES: {}", logId);
+        elasticsearchOperations.delete(String.valueOf(logId), TripLogSearchDoc.class);
+        log.info("Deleted trip log from ES: {}", logId);
     }
 
     private static String escapeJson(String s) {

--- a/src/main/java/com/ssafy/jjtrip/domain/search/service/TripSearchService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/service/TripSearchService.java
@@ -1,12 +1,14 @@
 package com.ssafy.jjtrip.domain.search.service;
 
 import com.ssafy.jjtrip.domain.search.dto.TripSearchDoc;
+import com.ssafy.jjtrip.domain.search.util.SearchUtil;
 import com.ssafy.jjtrip.domain.trip.entity.Trip;
 import com.ssafy.jjtrip.domain.trip.entity.TripItem;
 import com.ssafy.jjtrip.domain.trip.entity.TripVisibility;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
@@ -14,9 +16,9 @@ import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.stereotype.Service;
 
-@RequiredArgsConstructor
+@Slf4j
 @Service
-@lombok.extern.slf4j.Slf4j
+@RequiredArgsConstructor
 public class TripSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
@@ -55,7 +57,7 @@ public class TripSearchService {
             "minimum_should_match": 0
           }
         }
-        """.formatted(escapeJson(keyword), escapeJson(keyword));
+        """.formatted(SearchUtil.escapeJson(keyword), SearchUtil.escapeJson(keyword));
 
         Query query = new StringQuery(queryString);
         SearchHits<TripSearchDoc> searchHits = elasticsearchOperations.search(query, TripSearchDoc.class);
@@ -66,35 +68,15 @@ public class TripSearchService {
                 .collect(Collectors.toList());
     }
 
-    private String normalizeDate(String value, boolean isDateTime) {
-         if (value == null) return null;
-         if (value.matches("^\\d+$")) {
-             try {
-                 long millis = Long.parseLong(value);
-                 java.time.ZonedDateTime zdt = java.time.Instant.ofEpochMilli(millis)
-                         .atZone(java.time.ZoneId.systemDefault());
-                 
-                 if (isDateTime) {
-                     return zdt.toLocalDateTime().toString(); // YYYY-MM-DDTHH:MM:SS
-                 } else {
-                     return zdt.toLocalDate().toString(); // YYYY-MM-DD
-                 }
-             } catch (Exception e) {
-                 return value;
-             }
-         }
-         return value;
-    }
-
     private TripSearchDoc normalizeDoc(TripSearchDoc doc) { // Redefining for correctness
           return new TripSearchDoc(
                 doc.tripId(),
                 doc.userId(),
                 doc.title(),
                 doc.locationSummary(),
-                normalizeDate(doc.startDate(), false),
-                normalizeDate(doc.endDate(), false),
-                normalizeDate(doc.createdAt(), true),
+                SearchUtil.normalizeDate(doc.startDate(), false),
+                SearchUtil.normalizeDate(doc.endDate(), false),
+                SearchUtil.normalizeDate(doc.createdAt(), true),
                 doc.spotNames(),
                 doc.spotCategories(),
                 doc.spotsPreview()
@@ -116,7 +98,6 @@ public class TripSearchService {
                 .toList();
 
         List<TripSearchDoc.SpotPreview> spotsPreview = items.stream()
-                .limit(3)
                 .map(item -> new TripSearchDoc.SpotPreview(
                         item.getSpot().getId(),
                         item.getSpot().getName(),
@@ -146,30 +127,5 @@ public class TripSearchService {
         log.info("Deleting trip from ES: {}", tripId);
         elasticsearchOperations.delete(String.valueOf(tripId), TripSearchDoc.class);
         log.info("Deleted trip from ES: {}", tripId);
-    }
-
-    private static String escapeJson(String s) {
-        if (s == null) return "";
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < s.length(); i++) {
-            char c = s.charAt(i);
-            switch (c) {
-                case '"' -> sb.append("\\\"");
-                case '\\' -> sb.append("\\\\");
-                case '\b' -> sb.append("\\b");
-                case '\f' -> sb.append("\\f");
-                case '\n' -> sb.append("\\n");
-                case '\r' -> sb.append("\\r");
-                case '\t' -> sb.append("\\t");
-                default -> {
-                    if (c < ' ') {
-                        sb.append(String.format("\\u%04x", (int) c));
-                    } else {
-                        sb.append(c);
-                    }
-                }
-            }
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/search/service/TripSearchService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/service/TripSearchService.java
@@ -1,6 +1,11 @@
 package com.ssafy.jjtrip.domain.search.service;
 
 import com.ssafy.jjtrip.domain.search.dto.TripSearchDoc;
+import com.ssafy.jjtrip.domain.trip.entity.Trip;
+import com.ssafy.jjtrip.domain.trip.entity.TripItem;
+import com.ssafy.jjtrip.domain.trip.entity.TripVisibility;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.SearchHit;
@@ -8,11 +13,10 @@ import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.data.elasticsearch.core.query.StringQuery;
 import org.springframework.stereotype.Service;
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
+@lombok.extern.slf4j.Slf4j
 public class TripSearchService {
 
     private final ElasticsearchOperations elasticsearchOperations;
@@ -58,7 +62,90 @@ public class TripSearchService {
 
         return searchHits.stream()
                 .map(SearchHit::getContent)
+                .map(this::normalizeDoc) // Normalize mixed date formats
                 .collect(Collectors.toList());
+    }
+
+    private String normalizeDate(String value, boolean isDateTime) {
+         if (value == null) return null;
+         if (value.matches("^\\d+$")) {
+             try {
+                 long millis = Long.parseLong(value);
+                 java.time.ZonedDateTime zdt = java.time.Instant.ofEpochMilli(millis)
+                         .atZone(java.time.ZoneId.systemDefault());
+                 
+                 if (isDateTime) {
+                     return zdt.toLocalDateTime().toString(); // YYYY-MM-DDTHH:MM:SS
+                 } else {
+                     return zdt.toLocalDate().toString(); // YYYY-MM-DD
+                 }
+             } catch (Exception e) {
+                 return value;
+             }
+         }
+         return value;
+    }
+
+    private TripSearchDoc normalizeDoc(TripSearchDoc doc) { // Redefining for correctness
+          return new TripSearchDoc(
+                doc.tripId(),
+                doc.userId(),
+                doc.title(),
+                doc.locationSummary(),
+                normalizeDate(doc.startDate(), false),
+                normalizeDate(doc.endDate(), false),
+                normalizeDate(doc.createdAt(), true),
+                doc.spotNames(),
+                doc.spotCategories(),
+                doc.spotsPreview()
+        );
+    }
+
+    public void saveTrip(Trip trip, List<TripItem> items) {
+        if (trip.getVisibility() != TripVisibility.PUBLIC) {
+            deleteTrip(trip.getId());
+            return;
+        }
+
+        List<String> spotNames = items.stream()
+                .map(item -> item.getSpot().getName())
+                .toList();
+
+        List<String> spotCategories = items.stream()
+                .map(item -> item.getSpot().getCategory())
+                .toList();
+
+        List<TripSearchDoc.SpotPreview> spotsPreview = items.stream()
+                .limit(3)
+                .map(item -> new TripSearchDoc.SpotPreview(
+                        item.getSpot().getId(),
+                        item.getSpot().getName(),
+                        item.getSpot().getCategory()
+                ))
+                .toList();
+
+        TripSearchDoc doc = new TripSearchDoc(
+                trip.getId(),
+                trip.getUserId(),
+                trip.getTitle(),
+                trip.getLocationSummary(),
+                trip.getStartDate() != null ? trip.getStartDate().toString() : null,
+                trip.getEndDate() != null ? trip.getEndDate().toString() : null,
+                trip.getCreatedAt() != null ? trip.getCreatedAt().toString() : null,
+                spotNames,
+                spotCategories,
+                spotsPreview
+        );
+
+        log.info("Saving trip to ES: {}", trip.getId());
+        elasticsearchOperations.save(doc);
+        log.info("Saved trip to ES: {}", trip.getId());
+    }
+
+    public void deleteTrip(Long tripId) {
+        log.info("Deleting trip from ES: {}", tripId);
+        elasticsearchOperations.delete(String.valueOf(tripId), TripSearchDoc.class);
+        log.info("Deleted trip from ES: {}", tripId);
     }
 
     private static String escapeJson(String s) {

--- a/src/main/java/com/ssafy/jjtrip/domain/search/util/SearchUtil.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/search/util/SearchUtil.java
@@ -1,0 +1,50 @@
+package com.ssafy.jjtrip.domain.search.util;
+
+public class SearchUtil {
+
+    private SearchUtil() {}
+
+    public static String normalizeDate(String value, boolean isDateTime) {
+        if (value == null) return null;
+        if (value.matches("^\\d+$")) {
+            try {
+                long millis = Long.parseLong(value);
+                java.time.ZonedDateTime zdt = java.time.Instant.ofEpochMilli(millis)
+                        .atZone(java.time.ZoneId.systemDefault());
+                if (isDateTime) {
+                    return zdt.toLocalDateTime().toString();
+                } else {
+                    return zdt.toLocalDate().toString();
+                }
+            } catch (Exception e) {
+                return value;
+            }
+        }
+        return value;
+    }
+
+    public static String escapeJson(String s) {
+        if (s == null) return "";
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"' -> sb.append("\\\"");
+                case '\\' -> sb.append("\\\\");
+                case '\b' -> sb.append("\\b");
+                case '\f' -> sb.append("\\f");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < ' ') {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/trip/service/TripService.java
@@ -1,5 +1,6 @@
 package com.ssafy.jjtrip.domain.trip.service;
 
+import com.ssafy.jjtrip.domain.search.service.TripSearchService;
 import com.ssafy.jjtrip.domain.spot.service.SpotService;
 import com.ssafy.jjtrip.domain.trip.dto.TripItemsReplaceRequestDto;
 import com.ssafy.jjtrip.domain.trip.dto.TripResponseDto;
@@ -11,6 +12,10 @@ import com.ssafy.jjtrip.domain.trip.entity.TripVisibility;
 import com.ssafy.jjtrip.domain.trip.exception.TripErrorCode;
 import com.ssafy.jjtrip.domain.trip.exception.TripException;
 import com.ssafy.jjtrip.domain.trip.mapper.TripMapper;
+import com.ssafy.jjtrip.domain.search.service.TripLogSearchService;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLog;
+import com.ssafy.jjtrip.domain.triplog.mapper.TripLogMapper;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,6 +29,9 @@ public class TripService {
     private final TripMapper tripMapper;
     private final SpotService spotService;
     private final LocationSummaryService locationSummaryService;
+    private final TripSearchService tripSearchService;
+    private final TripLogMapper tripLogMapper;
+    private final TripLogSearchService tripLogSearchService;
 
     @Transactional
     public Trip createTrip(Long userId) {
@@ -35,6 +43,10 @@ public class TripService {
                 .build();
         tripMapper.insert(newTrip);
         newTrip.setTripItems(new java.util.ArrayList<>()); // Initialize tripItems to prevent NPE
+        
+        // ES Sync (Private by default, but ensuring sync logic)
+        tripSearchService.saveTrip(newTrip, newTrip.getTripItems());
+        
         return newTrip;
     }
 
@@ -87,12 +99,23 @@ public class TripService {
         if (requestDto.visibility() != null) trip.setVisibility(requestDto.visibility());
 
         tripMapper.update(trip);
+        
+        List<TripItem> items = tripMapper.selectItemsWithSpotsByTripId(tripId);
+        tripSearchService.saveTrip(trip, items);
+
+        // Sync associated logs to ES (e.g., when visibility changes)
+        List<TripLog> tripLogs = tripLogMapper.findByTripId(tripId);
+        for (TripLog log : tripLogs) {
+            List<String> imageUrls = extractImageUrls(log.getContent());
+            tripLogSearchService.saveTripLog(log, trip, imageUrls);
+        }
     }
 
     @Transactional
     public void deleteTrip(Long tripId, Long userId) {
         getTripForModification(tripId, userId);
         tripMapper.delete(tripId);
+        tripSearchService.deleteTrip(tripId);
     }
 
     @Transactional
@@ -110,6 +133,11 @@ public class TripService {
         }
 
         locationSummaryService.updateLocationSummary(tripId);
+        
+        // Sync to ES
+        Trip trip = findTripById(tripId);
+        List<TripItem> items = tripMapper.selectItemsWithSpotsByTripId(tripId);
+        tripSearchService.saveTrip(trip, items);
     }
 
     private Long resolveSpotId(TripItemsReplaceRequestDto.Item item) {
@@ -157,6 +185,10 @@ public class TripService {
         copyTripItems(tripId, newTrip.getId());
         locationSummaryService.updateLocationSummary(newTrip.getId());
         
+        // Sync new scrap trip (Private by default)
+        List<TripItem> items = tripMapper.selectItemsWithSpotsByTripId(newTrip.getId());
+        tripSearchService.saveTrip(newTrip, items);
+        
         return newTrip.getId();
     }
 
@@ -180,5 +212,16 @@ public class TripService {
                     item.getOrderIndex()
             );
         }
+    }
+
+    private List<String> extractImageUrls(String content) {
+        if (content == null || content.isBlank()) return Collections.emptyList();
+        List<String> urls = new java.util.ArrayList<>();
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("!\\[.*?\\]\\((.*?)\\)");
+        java.util.regex.Matcher matcher = pattern.matcher(content);
+        while (matcher.find()) {
+            urls.add(matcher.group(1));
+        }
+        return urls;
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -5,8 +5,10 @@ import com.ssafy.jjtrip.domain.triplog.dto.response.TripLogDetailResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.response.TripLogFeedResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.response.TripLogImageResponseDto;
 import com.ssafy.jjtrip.domain.triplog.dto.response.TripLogSummaryDto;
+import com.ssafy.jjtrip.domain.triplog.entity.TripLog;
 import com.ssafy.jjtrip.domain.triplog.entity.TripLogComment;
 import com.ssafy.jjtrip.domain.triplog.entity.TripLogVisibility;
+import com.ssafy.jjtrip.domain.user.dto.AiAnalysisRequestDto;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +30,7 @@ public interface TripLogMapper {
 
     @Insert("INSERT INTO trip_log (trip_id, title, content, visibility) VALUES (#{tripId}, #{title}, #{content}, #{visibility})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
-    void insertTripLog(com.ssafy.jjtrip.domain.triplog.entity.TripLog tripLog);
+    void insertTripLog(TripLog tripLog);
 
     @Insert("INSERT INTO log_image (log_id, user_id, image_url, order_index, image_ref_key) " +
             "VALUES (#{logId}, #{userId}, #{imageUrl}, #{orderIndex}, #{imageRefKey})")
@@ -258,7 +260,7 @@ public interface TripLogMapper {
             WHERE id = #{id}
             </script>
             """)
-    void updateTripLog(com.ssafy.jjtrip.domain.triplog.entity.TripLog tripLog);
+    void updateTripLog(TripLog tripLog);
 
     @Select("""
             SELECT t.user_id
@@ -267,6 +269,12 @@ public interface TripLogMapper {
             WHERE tl.id = #{logId}
             """)
     Optional<Long> findAuthorIdByLogId(Long logId);
+
+    @Select("SELECT id, trip_id, title, content, visibility, created_at, updated_at FROM trip_log WHERE id = #{id}")
+    Optional<TripLog> findById(Long id);
+
+    @Select("SELECT id, trip_id, title, content, visibility, created_at, updated_at FROM trip_log WHERE trip_id = #{tripId}")
+    List<TripLog> findByTripId(Long tripId);
 
     @Delete("DELETE FROM trip_log WHERE id = #{logId}")
     void deleteTripLog(Long logId);
@@ -299,7 +307,7 @@ public interface TripLogMapper {
             @Arg(column = "content", javaType = String.class),
             @Arg(column = "spotCategories", javaType = String.class)
     })
-    List<com.ssafy.jjtrip.domain.user.dto.AiAnalysisRequestDto.LogItem> findLogsForAnalysis(Long userId);
+    List<AiAnalysisRequestDto.LogItem> findLogsForAnalysis(Long userId);
 
     @Update("UPDATE log_comment SET content = #{content}, updated_at = NOW() WHERE id = #{commentId}")
     void updateComment(@Param("commentId") Long commentId, @Param("content") String content);

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -2,6 +2,8 @@ package com.ssafy.jjtrip.domain.triplog.service;
 
 import com.ssafy.jjtrip.common.dto.PageDto;
 import com.ssafy.jjtrip.common.dto.SliceDto;
+import com.ssafy.jjtrip.domain.search.service.TripLogSearchService;
+import com.ssafy.jjtrip.domain.trip.entity.Trip;
 import com.ssafy.jjtrip.domain.trip.service.TripService;
 import com.ssafy.jjtrip.domain.triplog.dto.request.TripLogCreateRequestDto;
 import com.ssafy.jjtrip.domain.triplog.dto.request.TripLogUpdateRequestDto;
@@ -34,6 +36,7 @@ public class TripLogService {
     private final TripService tripService;
     private final TripLogCommentService tripLogCommentService;
     private final TripLogLikeService tripLogLikeService;
+    private final TripLogSearchService tripLogSearchService;
 
     @Transactional
     public TripLogCreateResponseDto createTripLog(Long userId, TripLogCreateRequestDto requestDto) {
@@ -54,6 +57,11 @@ public class TripLogService {
 
         tripLogMapper.insertTripLog(tripLog);
         processAndSaveImages(tripLog.getId(), userId, requestDto.content());
+
+        // Sync ES
+        Trip trip = tripService.getTripDetail(requestDto.tripId(), userId);
+        List<String> imageUrls = extractImageUrls(tripLog.getContent());
+        tripLogSearchService.saveTripLog(tripLog, trip, imageUrls);
 
         return new TripLogCreateResponseDto(tripLog.getId());
     }
@@ -109,12 +117,22 @@ public class TripLogService {
         return TripLogDetailResponseDto.from(baseInfo, images, comments, likeCount, commentCount);
     }
     
-
+    // Private helper for extracting URLs to avoid duplicating regex logic
+    private List<String> extractImageUrls(String content) {
+        if (content == null || content.isBlank()) return Collections.emptyList();
+        List<String> urls = new java.util.ArrayList<>();
+        java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("!\\[.*?\\]\\((.*?)\\)");
+        java.util.regex.Matcher matcher = pattern.matcher(content);
+        while (matcher.find()) {
+            urls.add(matcher.group(1));
+        }
+        return urls;
+    }
 
     @Transactional
     public void updateTripLog(Long logId, Long userId, TripLogUpdateRequestDto requestDto) {
         validateLogAuthor(logId, userId);
-
+        
         TripLog tripLog = TripLog.builder()
                 .id(logId)
                 .title(requestDto.title())
@@ -128,6 +146,13 @@ public class TripLogService {
             tripLogMapper.deleteLogImages(logId);
             processAndSaveImages(logId, userId, requestDto.content());
         }
+        
+        // Sync ES
+        // Need full TripLog and Trip data
+        TripLog updatedLog = tripLogMapper.findById(logId).orElseThrow(); 
+        Trip trip = tripService.getTripDetail(updatedLog.getTripId(), userId);
+        List<String> imageUrls = extractImageUrls(updatedLog.getContent());
+        tripLogSearchService.saveTripLog(updatedLog, trip, imageUrls);
     }
 
     private void processAndSaveImages(Long logId, Long userId, String content) {
@@ -154,6 +179,7 @@ public class TripLogService {
     public void deleteTripLog(Long logId, Long userId) {
         validateLogAuthor(logId, userId);
         tripLogMapper.deleteTripLog(logId);
+        tripLogSearchService.deleteTripLog(logId);
     }
 
     private void validateLogAuthor(Long logId, Long userId) {


### PR DESCRIPTION
# Issue
- close #47

# Details

## 🔍 배경
- **TripLog 검색 동기화 구현**: 기존에는 **TripLog 생성/수정/삭제(CUD) 시 Elasticsearch에 반영되는 로직이 아예 존재하지 않아**, DB와 검색 결과가 일치하지 않는 문제가 있었습니다. 이를 해결하기 위해 동기화 로직을 신규 구현했습니다.
- **Trip 공개 전환 동기화**: Trip 공개 여부(`Visibility`) 변경 시 연관된 TripLog들이 즉시 검색에 반영되도록 처리했습니다.
- **날짜 포맷 에러 수정**: Elasticsearch에서 반환되는 날짜 형식이 제각각(ISO String vs Epoch Millis)이라 발생하는 `ConversionException`을 근본적으로 해결해야 했습니다.

## 🛠️ 주요 변경 사항

### 1. Trip & TripLog CUD 동기화 (Elasticsearch Sync)
기존에 **누락되어 있던 TripLog의 동기화 로직을 새롭게 구현**하고, Trip의 동기화 로직을 보완했습니다. MySQL에서의 변경 사항이 Elasticsearch에 즉시 반영되도록 서비스 레이어(`Service`)에서 처리합니다. **모든 인덱싱은 `PUBLIC` 상태일 때만 수행되며, `PRIVATE`인 경우 인덱스에서 제거됩니다.**

#### ✈️ 여행 (Trip)
- **생성 (`createTrip`, `scrapTrip`)**: 기본적으로 `PRIVATE`으로 생성되지만, 코드 일관성을 위해 `tripSearchService.saveTrip`을 호출하여 동기화 로직을 태웁니다. (비공개이므로 실제 ES에는 저장되지 않거나 삭제됨)
- **수정 (`updateTrip`)**:
    - 여행 정보(제목, 날짜 등)가 변경되면 ES 인덱스도 갱신합니다.
    - **핵심**: 여행의 공개 여부가 `PRIVATE` → `PUBLIC`으로 변경될 때, **연관된 모든 여행 기록(TripLog)을 찾아 자동으로 재색인(Re-indexing)** 합니다. (`syncTripLogsToElasticsearch`)
- **아이템 교체 (`replaceTripItems`)**: 여행 경로(Spot)가 변경되면 `location_summary`를 다시 계산하고 ES 문서를 갱신합니다.
- **삭제 (`deleteTrip`)**: DB에서 삭제됨과 동시에 ES 인덱스에서도 해당 여행 문서를 영구 삭제합니다.

#### 📝 여행 기록 (TripLog)
- **생성 (`createTripLog`)**: 기록 생성 시 부모 여행(`Trip`)과 본인(`TripLog`)이 모두 `PUBLIC`일 경우에만 ES에 인덱싱합니다.
- **수정 (`updateTripLog`)**:
    - 제목, 내용 변경 시 ES 문서를 갱신합니다.
    - 텍스트 내 이미지 URL(`![alt](url)`)을 다시 추출하여 썸네일 정보를 업데이트합니다.
- **삭제 (`deleteTripLog`)**: 기록 삭제 시 ES 인덱스에서도 즉시 삭제합니다.

### 2. Elasticsearch 날짜 정규화 (Normalization)
- **문제**: Elasticsearch는 상황에 따라 날짜를 `"2024-05-10"`(String) 또는 `1715...`(Long)으로 반환하여 Java 객체 매핑 시 에러가 발생했습니다.
- **해결**:
    - 검색 결과 DTO(`TripSearchDoc`, `TripLogSearchDoc`)의 모든 날짜 필드를 `String` 타입으로 통일했습니다.
    - `SearchUtil.normalizeDate` 유틸리티를 도입하여, ES가 숫자로 반환하더라도 조회 시점에 **표준 ISO 8601 포맷**으로 자동 변환해 프론트엔드에 전달합니다.

### 3. API 문서 최신화 (`api-docs.yaml`)
- 실제 검색 DTO의 JSON 응답 키(`snake_case`)와 날짜 필드 타입(`string`)을 API 문서에 정확히 반영했습니다.
- 누락되었던 `trip_id`, `log_id`, `image_urls` 등 주요 필드를 문서 스키마에 추가했습니다.

## ✅ 테스트 항목
- [x] **Trip 생성/삭제**: `PRIVATE` 생성 시 미노출 확인, 삭제 시 검색 결과 제거 확인
- [x] **Trip 수정 동기화**: `PRIVATE` Trip을 `PUBLIC`으로 변경 시, 하위 `TripLog`들이 검색에 뜨는지 확인
- [x] **TripLog CRUD**: 기록 작성/수정/삭제 시 검색 결과에 실시간 반영 확인
- [x] **날짜 포맷**: 다양한 날짜 형식의 데이터가 검색되어도 에러 없이 ISO String으로 반환되는지 확인
