### PR TITLE
feat: 친구 신청 수락/거절 및 보낸 친구 신청 취소 API 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +52,35 @@ public class FriendController {
         Long userId = userDetails.getUser().getId();
         List<FriendRequestResponseDto> sentRequests = friendService.getSentRequests(userId);
         return ResponseEntity.ok(sentRequests);
+    }
+
+    @PostMapping("/requests/{requestId}/accept")
+    public ResponseEntity<Void> acceptRequest(
+            @PathVariable Long requestId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long acceptingUserId = userDetails.getUser().getId();
+        friendService.acceptRequest(requestId, acceptingUserId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); // 204 No Content for successful update/delete
+    }
+
+    @PostMapping("/requests/{requestId}/decline")
+    public ResponseEntity<Void> declineRequest(
+            @PathVariable Long requestId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long decliningUserId = userDetails.getUser().getId();
+        friendService.declineRequest(requestId, decliningUserId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build(); // 204 No Content for successful update/delete
+    }
+
+    @DeleteMapping("/requests/sent/{requestId}")
+    public ResponseEntity<Void> cancelSentRequest(
+            @PathVariable Long requestId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long cancellingUserId = userDetails.getUser().getId();
+        friendService.cancelSentRequest(requestId, cancellingUserId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/exception/FriendErrorCode.java
@@ -14,7 +14,8 @@ public enum FriendErrorCode implements ErrorCode {
     REQUEST_ALREADY_EXISTS(HttpStatus.CONFLICT, "FRIEND-003", "처리 대기 중이거나 이미 수락된 친구 요청이 존재합니다."),
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND-004", "존재하지 않는 친구 요청입니다."),
     NOT_THE_RECEIVER(HttpStatus.FORBIDDEN, "FRIEND-005", "친구요청을 받은 사용자만 처리할 수 있습니다."),
-    NOT_THE_REQUESTER(HttpStatus.FORBIDDEN, "FRIEND-006", "친구요청을 보낸 사용자만 취소할 수 있습니다.");
+    NOT_THE_REQUESTER(HttpStatus.FORBIDDEN, "FRIEND-006", "친구요청을 보낸 사용자만 취소할 수 있습니다."),
+    REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, "FRIEND-007", "이미 처리된 요청입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
@@ -32,7 +32,8 @@ public interface FriendMapper {
     Optional<Friendship> findFriendshipByUsers(@Param("userIdA") Long userIdA, @Param("userIdB") Long userIdB);
 
     // 3. ID로 친구 요청 조회
-
+    @Select("SELECT id, requester_id, receiver_id, status, created_at FROM friend_request WHERE id = #{requestId}")
+    Optional<FriendRequest> findRequestById(@Param("requestId") Long requestId);
 
     // 4. 받은 친구 요청 목록 조회
     @Select("SELECT fr.id as requestId, fr.status, fr.created_at as createdAt, " +
@@ -66,9 +67,15 @@ public interface FriendMapper {
             @Result(property = "user.profileImageUrl", column = "profileImageUrl")
     })
     List<FriendRequestResponseDto> findSentRequestsByUserId(@Param("userId") Long userId);
-    
+
     // 6. 친구 요청 삭제
+    @Delete("DELETE FROM friend_request WHERE id = #{requestId}")
+    int deleteRequestById(@Param("requestId") Long requestId);
+    
     // 7. 친구 관계 생성
+    @Insert("INSERT INTO friendship (user_id_a, user_id_b) VALUES (#{userIdA}, #{userIdB})")
+    void saveFriendship(Friendship friendship);
+
     // 8. 친구 관계 삭제
     // 9. 친구 목록 조회
     // 10. 친구 피드 목록 조회

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -4,6 +4,7 @@ import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
+import com.ssafy.jjtrip.domain.friend.entity.Friendship;
 import com.ssafy.jjtrip.domain.friend.exception.FriendErrorCode;
 import com.ssafy.jjtrip.domain.friend.exception.FriendException;
 import com.ssafy.jjtrip.domain.friend.mapper.FriendMapper;
@@ -63,5 +64,76 @@ public class FriendService {
 
     public List<FriendRequestResponseDto> getSentRequests(Long userId) {
         return friendMapper.findSentRequestsByUserId(userId);
+    }
+
+    @Transactional
+    public void acceptRequest(Long requestId, Long acceptingUserId) {
+        FriendRequest friendRequest = friendMapper.findRequestById(requestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.REQUEST_NOT_FOUND));
+
+        // 요청을 수락하는 사용자가 해당 요청의 수신자인지 확인
+        if (!friendRequest.getReceiverId().equals(acceptingUserId)) {
+            throw new FriendException(FriendErrorCode.NOT_THE_RECEIVER);
+        }
+
+        // 요청 상태가 PENDING인지 확인
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
+        }
+
+        // friendship 테이블에 친구 관계 추가 (중복 방지를 위해 항상 작은 ID, 큰 ID 순서로 저장)
+        long userIdA = Math.min(friendRequest.getRequesterId(), friendRequest.getReceiverId());
+        long userIdB = Math.max(friendRequest.getRequesterId(), friendRequest.getReceiverId());
+
+        friendMapper.findFriendshipByUsers(userIdA, userIdB).ifPresent(friendship -> {
+            throw new FriendException(FriendErrorCode.ALREADY_FRIENDS);
+        });
+
+        Friendship friendship = Friendship.builder()
+                .userIdA(userIdA)
+                .userIdB(userIdB)
+                .build();
+        friendMapper.saveFriendship(friendship);
+
+        // 친구 요청 기록 삭제
+        friendMapper.deleteRequestById(requestId);
+    }
+
+    @Transactional
+    public void declineRequest(Long requestId, Long decliningUserId) {
+        FriendRequest friendRequest = friendMapper.findRequestById(requestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.REQUEST_NOT_FOUND));
+
+        // 요청을 거절하는 사용자가 해당 요청의 수신자인지 확인
+        if (!friendRequest.getReceiverId().equals(decliningUserId)) {
+            throw new FriendException(FriendErrorCode.NOT_THE_RECEIVER);
+        }
+
+        // 요청 상태가 PENDING인지 확인
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
+        }
+
+        // 친구 요청 기록 삭제
+        friendMapper.deleteRequestById(requestId);
+    }
+
+    @Transactional
+    public void cancelSentRequest(Long requestId, Long cancellingUserId) {
+        FriendRequest friendRequest = friendMapper.findRequestById(requestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.REQUEST_NOT_FOUND));
+
+        // 요청을 취소하는 사용자가 해당 요청의 송신자인지 확인
+        if (!friendRequest.getRequesterId().equals(cancellingUserId)) {
+            throw new FriendException(FriendErrorCode.NOT_THE_REQUESTER);
+        }
+
+        // 요청 상태가 PENDING인지 확인
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
+        }
+
+        // 친구 요청 기록 삭제
+        friendMapper.deleteRequestById(requestId);
     }
 }


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 **받은 친구 신청의 수락/거절, 보낸 친구 신청 취소 API를 구현**했습니다.

### ✔️ 주요 변경 사항
API 구현을 위해 Controller, Service, Mapper 파일을 수정하고, 새로운 커스텀 에러 코드를 정의했습니다.

---

### 📘 API 명세
POST `/api/friends/requests/{requestId}/accept`
  - **성공 (`204 No Content`)**
  - **요청 ID를 찾을 수 없을 때 (`404 Not Found`)**
  - **로그인한 사용자가 요청의 수신자가 아닐 때 (`403 Forbidden`)**
  - **요청이 이미 처리되었을 때 (`409 Conflict`)**
  - **이미 친구 관계일 때 (`409 Conflict`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

POST `/api/friends/requests/{requestId}/decline`
  - **성공 (`204 No Content`)**
  - **요청 ID를 찾을 수 없을 때 (`404 Not Found`)**
  - **로그인한 사용자가 요청의 수신자가 아닐 때 (`403 Forbidden`)**
  - **요청이 이미 처리되었을 때 (`409 Conflict`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

DELETE `/api/friends/requests/sent/{requestId}`
  - **성공 (`204 No Content`)**
  - **요청 ID를 찾을 수 없을 때 (`404 Not Found`)**
  - **로그인한 사용자가 요청의 송신자가 아닐 때 (`403 Forbidden`)**
  - **요청이 이미 처리되었을 때 (`409 Conflict`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

---

### 🚧 특이사항
친구 신청이 어떠한 형태로든 처리(수락, 거절, 취소)되면, DB에서 해당 데이터를 삭제하도록 구현했습니다.
이에 따라 친구 신청의 status 관리가 필요하지 않게 되었습니다.
 
---

### 📅 향후 계획
- **`friend_request` 테이블에서 `status` 컬럼을 제거**합니다.
- 친구 기능을 위한 **나머지 API를 개발**합니다.
  - 친구 목록 조회
  - 친구 삭제
  - 친구 피드 조회