### PR TITLE
refactor: 친구 신청 상태 관리 로직 제거 및 단순화

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/dto/response/FriendRequestResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/dto/response/FriendRequestResponseDto.java
@@ -1,6 +1,5 @@
 package com.ssafy.jjtrip.domain.friend.dto.response;
 
-import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,6 +14,5 @@ import java.time.LocalDateTime;
 public class FriendRequestResponseDto {
     private Long requestId;
     private SimpleUserInfoDto user; // 요청을 보낸 사람 또는 받은 사람
-    private FriendRequestStatus status;
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/entity/FriendRequest.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/entity/FriendRequest.java
@@ -13,5 +13,4 @@ import lombok.experimental.SuperBuilder;
 public class FriendRequest extends BaseEntityWithUpdate {
     private Long requesterId;
     private Long receiverId;
-    private FriendRequestStatus status;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/entity/FriendRequestStatus.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/entity/FriendRequestStatus.java
@@ -1,7 +1,0 @@
-package com.ssafy.jjtrip.domain.friend.entity;
-
-public enum FriendRequestStatus {
-    PENDING,
-    ACCEPTED,
-    DECLINED
-}

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
@@ -1,8 +1,8 @@
 package com.ssafy.jjtrip.domain.friend.mapper;
 
 import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
+import com.ssafy.jjtrip.domain.friend.dto.response.SimpleUserInfoDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
-import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
 import com.ssafy.jjtrip.domain.friend.entity.Friendship;
 import org.apache.ibatis.annotations.*;
 
@@ -12,14 +12,10 @@ import java.util.Optional;
 @Mapper
 public interface FriendMapper {
     // 1. 친구 요청 생성
-    @Insert("INSERT INTO friend_request (requester_id, receiver_id, status) " +
-            "VALUES (#{requesterId}, #{receiverId}, #{status})")
+    @Insert("INSERT INTO friend_request (requester_id, receiver_id) " +
+            "VALUES (#{requesterId}, #{receiverId})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void saveRequest(FriendRequest friendRequest);
-
-    // 2. 친구 요청 상태 변경 (수락, 거절)
-    @Update("UPDATE friend_request SET status = #{status} WHERE id = #{requestId}")
-    int updateRequestStatus(@Param("requestId") Long requestId, @Param("status") FriendRequestStatus status);
 
     // 중복 요청 검증용
     @Select("SELECT * FROM friend_request " +
@@ -32,18 +28,17 @@ public interface FriendMapper {
     Optional<Friendship> findFriendshipByUsers(@Param("userIdA") Long userIdA, @Param("userIdB") Long userIdB);
 
     // 3. ID로 친구 요청 조회
-    @Select("SELECT id, requester_id, receiver_id, status, created_at FROM friend_request WHERE id = #{requestId}")
+    @Select("SELECT id, requester_id, receiver_id, created_at FROM friend_request WHERE id = #{requestId}")
     Optional<FriendRequest> findRequestById(@Param("requestId") Long requestId);
 
     // 4. 받은 친구 요청 목록 조회
-    @Select("SELECT fr.id as requestId, fr.status, fr.created_at as createdAt, " +
+    @Select("SELECT fr.id as requestId, fr.created_at as createdAt, " +
             "u.id as userId, u.nickname, u.profile_image_url as profileImageUrl " +
             "FROM friend_request fr " +
             "JOIN user u ON fr.requester_id = u.id " +
-            "WHERE fr.receiver_id = #{userId} AND fr.status = 'PENDING'")
+            "WHERE fr.receiver_id = #{userId}")
     @Results({
             @Result(property = "requestId", column = "requestId"),
-            @Result(property = "status", column = "status"),
             @Result(property = "createdAt", column = "createdAt"),
             @Result(property = "user.userId", column = "userId"),
             @Result(property = "user.nickname", column = "nickname"),
@@ -53,14 +48,13 @@ public interface FriendMapper {
 
 
     // 5. 보낸 친구 요청 목록 조회
-    @Select("SELECT fr.id as requestId, fr.status, fr.created_at as createdAt, " +
+    @Select("SELECT fr.id as requestId, fr.created_at as createdAt, " +
             "u.id as userId, u.nickname, u.profile_image_url as profileImageUrl " +
             "FROM friend_request fr " +
             "JOIN user u ON fr.receiver_id = u.id " +
             "WHERE fr.requester_id = #{userId}")
     @Results({
             @Result(property = "requestId", column = "requestId"),
-            @Result(property = "status", column = "status"),
             @Result(property = "createdAt", column = "createdAt"),
             @Result(property = "user.userId", column = "userId"),
             @Result(property = "user.nickname", column = "nickname"),
@@ -77,6 +71,10 @@ public interface FriendMapper {
     void saveFriendship(Friendship friendship);
 
     // 8. 친구 관계 삭제
+    @Delete("DELETE FROM friendship WHERE (user_id_a = #{userId1} AND user_id_b = #{userId2}) OR (user_id_a = #{userId2} AND user_id_b = #{userId1})")
+    int deleteFriendship(@Param("userId1") Long userId1, @Param("userId2") Long userId2);
+
+
     // 9. 친구 목록 조회
     // 10. 친구 피드 목록 조회
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -3,7 +3,6 @@ package com.ssafy.jjtrip.domain.friend.service;
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
-import com.ssafy.jjtrip.domain.friend.entity.FriendRequestStatus;
 import com.ssafy.jjtrip.domain.friend.entity.Friendship;
 import com.ssafy.jjtrip.domain.friend.exception.FriendErrorCode;
 import com.ssafy.jjtrip.domain.friend.exception.FriendException;
@@ -14,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -44,16 +42,13 @@ public class FriendService {
 
         // 4. 이미 처리 대기 중인 요청이 있는지 검증 (양방향)
         friendMapper.findRequestByUsers(requesterId, receiverId).ifPresent(request -> {
-            if (request.getStatus() == FriendRequestStatus.PENDING || request.getStatus() == FriendRequestStatus.ACCEPTED) {
-                throw new FriendException(FriendErrorCode.REQUEST_ALREADY_EXISTS);
-            }
+            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_EXISTS);
         });
 
         // 5. 모든 검증 통과 후 요청 생성
         FriendRequest friendRequest = FriendRequest.builder()
                 .requesterId(requesterId)
                 .receiverId(receiverId)
-                .status(FriendRequestStatus.PENDING)
                 .build();
         friendMapper.saveRequest(friendRequest);
     }
@@ -74,11 +69,6 @@ public class FriendService {
         // 요청을 수락하는 사용자가 해당 요청의 수신자인지 확인
         if (!friendRequest.getReceiverId().equals(acceptingUserId)) {
             throw new FriendException(FriendErrorCode.NOT_THE_RECEIVER);
-        }
-
-        // 요청 상태가 PENDING인지 확인
-        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
-            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
         }
 
         // friendship 테이블에 친구 관계 추가 (중복 방지를 위해 항상 작은 ID, 큰 ID 순서로 저장)
@@ -109,11 +99,6 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.NOT_THE_RECEIVER);
         }
 
-        // 요청 상태가 PENDING인지 확인
-        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
-            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
-        }
-
         // 친구 요청 기록 삭제
         friendMapper.deleteRequestById(requestId);
     }
@@ -126,11 +111,6 @@ public class FriendService {
         // 요청을 취소하는 사용자가 해당 요청의 송신자인지 확인
         if (!friendRequest.getRequesterId().equals(cancellingUserId)) {
             throw new FriendException(FriendErrorCode.NOT_THE_REQUESTER);
-        }
-
-        // 요청 상태가 PENDING인지 확인
-        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
-            throw new FriendException(FriendErrorCode.REQUEST_ALREADY_PROCESSED);
         }
 
         // 친구 요청 기록 삭제

--- a/src/main/resources/trit-db-schema.sql
+++ b/src/main/resources/trit-db-schema.sql
@@ -76,7 +76,6 @@ CREATE TABLE `friend_request` (
                                   `id` BIGINT NOT NULL AUTO_INCREMENT,
                                   `requester_id` BIGINT NOT NULL COMMENT '요청 보낸 사용자 ID',
                                   `receiver_id`  BIGINT NOT NULL COMMENT '요청 받는 사용자 ID',
-                                  `status`       VARCHAR(20) NOT NULL DEFAULT 'PENDING' COMMENT "'PENDING', 'ACCEPTED', 'DECLINED'",
                                   `created_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                                   `updated_at`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
                                   PRIMARY KEY (`id`),

--- a/src/main/resources/trit-friend-request-dummy.sql
+++ b/src/main/resources/trit-friend-request-dummy.sql
@@ -1,4 +1,3 @@
-INSERT INTO `friend_request` (requester_id, receiver_id, status) VALUES
-(1, 2, 'PENDING'),
-(1, 3, 'ACCEPTED'),
-(2, 3, 'DECLINED');
+INSERT INTO `friend_request` (requester_id, receiver_id) VALUES
+(1, 2),
+(2, 3);


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 친구 신청(`friend_request`)의 상태(`status`) 관리 로직을 제거했습니다.

어떠한 형태로든 처리(수락/거절/취소)된 친구 신청은 DB에서 즉시 삭제하도록 함에 따라, `ACCEPTED`, `DECLINED` 등의 상태가 필요하지 않게 되었고, `friend_request` 테이블에 입력되는 모든 레코드는 `PENDING`이므로 status 컬럼을 제거할 수 있었습니다.

### ✔️ 주요 변경 사항
- `friend_request` 테이블에서 `status` 컬럼 제거
- `FriendRequest` 엔티티에서 `status` 필드 제거
- `FriendRequestResponseDto`에서 `status` 필드 제거
- `FriendService`에서 더 이상 `status`를 검증하지 않도록 변경
- `FriendMapper`에서 DB로부터 `status` 값을 가져오지 않도록 변경
 
---

### 📅 향후 계획
- 친구 기능을 위한 **나머지 API를 개발**합니다.
  - 친구 목록 조회
  - 친구 삭제
  - 친구 피드 조회