### PR TITLE
feat: 친구 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
@@ -3,6 +3,7 @@ package com.ssafy.jjtrip.domain.friend.controller;
 import com.ssafy.jjtrip.common.security.CustomUserDetails;
 import com.ssafy.jjtrip.domain.friend.dto.request.FriendRequestRequestDto;
 import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
+import com.ssafy.jjtrip.domain.friend.dto.response.SimpleUserInfoDto;
 import com.ssafy.jjtrip.domain.friend.service.FriendService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -82,5 +83,14 @@ public class FriendController {
         Long cancellingUserId = userDetails.getUser().getId();
         friendService.cancelSentRequest(requestId, cancellingUserId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SimpleUserInfoDto>> getFriendList(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        List<SimpleUserInfoDto> friendList = friendService.getFriendList(userId);
+        return ResponseEntity.ok(friendList);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/mapper/FriendMapper.java
@@ -76,5 +76,16 @@ public interface FriendMapper {
 
 
     // 9. 친구 목록 조회
+    @Select("SELECT u.id AS userId, u.nickname, u.profile_image_url AS profileImageUrl " +
+            "FROM friendship f " +
+            "JOIN user u ON (f.user_id_a = #{userId} AND u.id = f.user_id_b) OR (f.user_id_b = #{userId} AND u.id = f.user_id_a) " +
+            "WHERE f.user_id_a = #{userId} OR f.user_id_b = #{userId}")
+    @Results({
+            @Result(property = "userId", column = "userId"),
+            @Result(property = "nickname", column = "nickname"),
+            @Result(property = "profileImageUrl", column = "profileImageUrl")
+    })
+    List<SimpleUserInfoDto> findFriendsByUserId(@Param("userId") Long userId);
+
     // 10. 친구 피드 목록 조회
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -2,6 +2,7 @@ package com.ssafy.jjtrip.domain.friend.service;
 
 import com.ssafy.jjtrip.domain.auth.exception.AuthErrorCode;
 import com.ssafy.jjtrip.domain.friend.dto.response.FriendRequestResponseDto;
+import com.ssafy.jjtrip.domain.friend.dto.response.SimpleUserInfoDto;
 import com.ssafy.jjtrip.domain.friend.entity.FriendRequest;
 import com.ssafy.jjtrip.domain.friend.entity.Friendship;
 import com.ssafy.jjtrip.domain.friend.exception.FriendErrorCode;
@@ -70,7 +71,7 @@ public class FriendService {
         if (!friendRequest.getReceiverId().equals(acceptingUserId)) {
             throw new FriendException(FriendErrorCode.NOT_THE_RECEIVER);
         }
-
+        
         // friendship 테이블에 친구 관계 추가 (중복 방지를 위해 항상 작은 ID, 큰 ID 순서로 저장)
         long userIdA = Math.min(friendRequest.getRequesterId(), friendRequest.getReceiverId());
         long userIdB = Math.max(friendRequest.getRequesterId(), friendRequest.getReceiverId());
@@ -115,5 +116,9 @@ public class FriendService {
 
         // 친구 요청 기록 삭제
         friendMapper.deleteRequestById(requestId);
+    }
+
+    public List<SimpleUserInfoDto> getFriendList(Long userId) {
+        return friendMapper.findFriendsByUserId(userId);
     }
 }


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 **사용자의 친구 목록을 조회하는 API를 구현**했습니다.

### ✔️ 주요 변경 사항
**친구 목록을 반환하는 API**를 구현했습니다.
`@AuthenticationPrincipal` 어노테이션을 통해 사용자 본인의 친구 목록만 반환받을 수 있도록 검증 절차를 밟습니다.

**개별 친구 정보는 요약된 카드 형태로 화면에 제공**되기 때문에 **`SimpleUserInfoDto`**를 통해 `userId`, `nickname`, `profileImageUrl`만 담고 있습니다.
친구의 LOG 페이지로 이동할 땐 `userId`를 활용하여 GET `/api/{userId}/profile`을 호출합니다.

---

### 📘 API 명세
GET `/api/friends`
  - **성공 (`200 OK`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

---

### 🚧 특이사항
**현재 API는 모든 친구 목록을 한번에 반환**하고 있습니다.
추후에 **페이징 또는 무한 스크롤**을 적용하게 된다면 page와 size 파라미터를 받을 수 있도록 하고, Mapper의 SQL 쿼리에 LIMIT, OFFSET을 추가해야 합니다.
 
---

### 📅 향후 계획
- 친구 기능을 위한 **나머지 API를 개발**합니다.
  - 친구 삭제
  - 친구 피드 조회