### PR TITLE
feat: 친구 삭제 API 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/controller/FriendController.java
@@ -93,4 +93,14 @@ public class FriendController {
         List<SimpleUserInfoDto> friendList = friendService.getFriendList(userId);
         return ResponseEntity.ok(friendList);
     }
+
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<Void> deleteFriend(
+            @PathVariable Long friendId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long myUserId = userDetails.getUser().getId();
+        friendService.deleteFriend(myUserId, friendId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/exception/FriendErrorCode.java
@@ -15,7 +15,8 @@ public enum FriendErrorCode implements ErrorCode {
     REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND-004", "존재하지 않는 친구 요청입니다."),
     NOT_THE_RECEIVER(HttpStatus.FORBIDDEN, "FRIEND-005", "친구요청을 받은 사용자만 처리할 수 있습니다."),
     NOT_THE_REQUESTER(HttpStatus.FORBIDDEN, "FRIEND-006", "친구요청을 보낸 사용자만 취소할 수 있습니다."),
-    REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, "FRIEND-007", "이미 처리된 요청입니다.");
+    REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, "FRIEND-007", "이미 처리된 요청입니다."),
+    FRIENDSHIP_NOT_FOUND(HttpStatus.NOT_FOUND, "FRIEND-008", "친구 관계를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -121,4 +121,20 @@ public class FriendService {
     public List<SimpleUserInfoDto> getFriendList(Long userId) {
         return friendMapper.findFriendsByUserId(userId);
     }
+
+    @Transactional
+    public void deleteFriend(Long myUserId, Long friendId) {
+        // 1. 친구 ID가 유효한지 검증
+        userMapper.findById(friendId)
+                .orElseThrow(() -> new FriendException(AuthErrorCode.USER_NOT_FOUND));
+
+        // 2. 친구 관계가 존재하는지 검증
+        long userIdA = Math.min(myUserId, friendId);
+        long userIdB = Math.max(myUserId, friendId);
+        friendMapper.findFriendshipByUsers(userIdA, userIdB)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIENDSHIP_NOT_FOUND));
+
+        // 3. 친구 관계 삭제
+        friendMapper.deleteFriendship(userIdA, userIdB);
+    }
 }


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 **친구 삭제 API를 구현**했습니다.

### ✔️ 주요 변경 사항
**친구 삭제 API를 구현**했습니다.
팔로워/팔로잉 방식과 다르게, **둘 중 한 명이라도 관계를 끊으면 친구 관계가 해제됩니다.**

---

### 📘 API 명세
- GET `/api/friends`
  - **성공 (`200 OK`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**

- DELETE `/api/friends/{userId}`
  - **성공 (`204 No Content`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**
  - **존재하지 않는 사용자 (`404 Not Found`)**
  - **친구 관계가 아님 (`404 Not Found`)**

---

### 📅 향후 계획
- **친구 피드 조회 API를 개발**합니다.