### PR TITLE
feat: Spot 생성 API Upsert 방식으로 변경

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
@@ -2,9 +2,11 @@ package com.ssafy.jjtrip.domain.spot.controller;
 
 import com.ssafy.jjtrip.domain.spot.dto.SpotRequestDto;
 import com.ssafy.jjtrip.domain.spot.dto.SpotResponseDto;
+import com.ssafy.jjtrip.domain.spot.dto.SpotUpsertResult;
 import com.ssafy.jjtrip.domain.spot.entity.Spot;
 import com.ssafy.jjtrip.domain.spot.service.SpotService;
 import jakarta.validation.Valid;
+import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -34,9 +36,14 @@ public class SpotController {
     @PostMapping
     public ResponseEntity<SpotResponseDto> createSpot(@RequestBody @Valid SpotRequestDto spotRequestDto) {
         Spot spot = spotRequestDto.toEntity();
-        Spot createdSpot = spotService.createSpot(spot);
-        return ResponseEntity.created(java.net.URI.create("/spots/" + createdSpot.getId()))
-                .body(SpotResponseDto.from(createdSpot));
+        SpotUpsertResult result = spotService.upsertSpot(spot);
+        
+        if (result.isNew()) {
+            return ResponseEntity.created(URI.create("/spots/" + result.spot().getId()))
+                    .body(SpotResponseDto.from(result.spot()));
+        } else {
+            return ResponseEntity.ok(SpotResponseDto.from(result.spot()));
+        }
     }
 
     @GetMapping("/{spotId}")

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/dto/SpotUpsertResult.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/dto/SpotUpsertResult.java
@@ -1,0 +1,9 @@
+package com.ssafy.jjtrip.domain.spot.dto;
+
+import com.ssafy.jjtrip.domain.spot.entity.Spot;
+
+public record SpotUpsertResult(
+        Spot spot,
+        boolean isNew
+) {
+}

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
@@ -1,5 +1,6 @@
 package com.ssafy.jjtrip.domain.spot.service;
 
+import com.ssafy.jjtrip.domain.spot.dto.SpotUpsertResult;
 import com.ssafy.jjtrip.domain.spot.entity.Spot;
 import com.ssafy.jjtrip.domain.spot.exception.SpotErrorCode;
 import com.ssafy.jjtrip.domain.spot.exception.SpotException;
@@ -60,6 +61,15 @@ public class SpotService {
                 .orElseGet(() -> {
                     spotMapper.insert(spot);
                     return spot;
+                });
+    }
+
+    public SpotUpsertResult upsertSpot(Spot spot) {
+        return spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId())
+                .map(existingSpot -> new SpotUpsertResult(existingSpot, false))
+                .orElseGet(() -> {
+                    spotMapper.insert(spot);
+                    return new SpotUpsertResult(spot, true);
                 });
     }
 


### PR DESCRIPTION
## Issue
- close #90

## Details
### 1. Spot 생성 로직 개선 (Upsert 적용)
- 기존 문제점: 프론트엔드에서 장소 존재 여부를 확인하기 위해 GET 요청 후 404 Not Found가 발생하면 POST로 생성을 요청하는 방식이었습니다. 이로 인해 정상적인 흐름임에도 브라우저 콘솔에 404 에러 로그가 남는 불편함이 있었습니다.

- 해결 방안: 서버 측에서 Upsert 패턴을 적용하여, 존재하는 경우 해당 정보를 반환하고 없을 경우 생성 후 반환하도록 변경했습니다.
- POST /spots 요청 시 kakaoPlaceId를 기준으로 조회합니다.
  - 존재 시: 200 OK와 함께 기존 Spot 정보 반환
  - 신규 생성 시: 201 Created와 함께 생성된 Spot 정보 반환

이를 통해 프론트엔드는 단일 호출로 로직을 단순화하고 불필요한 에러 로그를 제거할 수 있습니다.
