### PR TITLE
feat: 친구 피드 조회 API 구현 및 Redis fan-out 적용

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
+++ b/src/main/java/com/ssafy/jjtrip/common/util/RedisUtil.java
@@ -1,8 +1,10 @@
 package com.ssafy.jjtrip.common.util;
 
 import java.time.Duration;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -25,5 +27,19 @@ public class RedisUtil {
 
     public boolean hasKey(String key) {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
+    }
+
+    public void zadd(String key, String value, double score) {
+        stringRedisTemplate.opsForZSet().add(key, value, score);
+    }
+
+    public Set<String> zrevrange(String key, long start, long end) {
+        return stringRedisTemplate.opsForZSet().reverseRange(key, start, end);
+    }
+
+    public Set<ZSetOperations.TypedTuple<String>> zrevrangeByScoreWithScores(
+            String key, double min, double max, long offset, long count
+    ) {
+        return stringRedisTemplate.opsForZSet().reverseRangeByScoreWithScores(key, min, max, offset, count);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/controller/TripLogController.java
@@ -32,6 +32,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/trip-logs")
@@ -90,6 +92,16 @@ public class TripLogController {
     ) {
         final Long memberId = (userDetails != null) ? userDetails.getUser().getId() : null;
         return ResponseEntity.ok(tripLogService.getTripLogFeed(cursor, limit, memberId));
+    }
+
+    @GetMapping("/feed/friends")
+    public ResponseEntity<SliceDto<TripLogFeedResponseDto>> getFriendTripLogFeed(
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") int limit,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUser().getId();
+        return ResponseEntity.ok(tripLogService.getFriendTripLogFeed(userId, cursor, limit, userId));
     }
 
     @GetMapping("/{logId}")

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/mapper/TripLogMapper.java
@@ -323,11 +323,49 @@ public interface TripLogMapper {
 
     @Select("SELECT log_id FROM log_comment WHERE id = #{commentId}")
     Optional<Long> findLogIdByCommentId(Long commentId);
-    @Select("SELECT tl.id AS logId, tl.title, " +
-            "(SELECT tli.image_url FROM log_image tli WHERE tli.log_id = tl.id ORDER BY tli.order_index ASC LIMIT 1) AS thumbnailUrl " +
-            "FROM trip_log tl " +
-            "JOIN trip t ON tl.trip_id = t.id " +
-            "WHERE t.user_id = #{userId}")
+
+    @Select("""
+            <script>
+            SELECT
+                tl.id AS logId,
+                u.id AS authorId,
+                u.nickname AS authorNickname,
+                u.profile_image_url AS authorImageUrl,
+                tl.title,
+                tl.content,
+                t.location_summary AS locationSummary,
+                (SELECT COUNT(*) FROM log_like ll WHERE ll.log_id = tl.id) AS likeCount,
+                (SELECT COUNT(*) FROM log_comment lc WHERE lc.log_id = tl.id) AS commentCount,
+                <if test="memberId != null">
+                    EXISTS(SELECT 1 FROM log_like ll WHERE ll.log_id = tl.id AND ll.user_id = #{memberId}) AS liked,
+                </if>
+                <if test="memberId == null">
+                    0 AS liked,
+                </if>
+                tl.created_at AS createdAt
+            FROM trip_log tl
+            JOIN trip t ON tl.trip_id = t.id
+            JOIN user u ON t.user_id = u.id
+            WHERE tl.id IN
+            <foreach item='item' collection='logIds' open='(' separator=',' close=')'>
+                #{item}
+            </foreach>
+            ORDER BY FIELD(tl.id,
+            <foreach item='item' collection='logIds' separator=','>
+                #{item}
+            </foreach>
+            )
+            </script>
+            """)
+    List<TripLogFeedResponseDto.FeedData> findLogsByIds(@Param("logIds") List<Long> logIds, @Param("memberId") Long memberId);
+
+    @Select("""
+            SELECT tl.id AS logId, tl.title,
+            (SELECT tli.image_url FROM log_image tli WHERE tli.log_id = tl.id ORDER BY tli.order_index ASC LIMIT 1) AS thumbnailUrl
+            FROM trip_log tl
+            JOIN trip t ON tl.trip_id = t.id
+            WHERE t.user_id = #{userId}
+            """)
     List<TripLogSummaryDto> findSummariesByUserId(@Param("userId") Long userId);
 
     @Select("""

--- a/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/triplog/service/TripLogService.java
@@ -2,6 +2,9 @@ package com.ssafy.jjtrip.domain.triplog.service;
 
 import com.ssafy.jjtrip.common.dto.PageDto;
 import com.ssafy.jjtrip.common.dto.SliceDto;
+import com.ssafy.jjtrip.common.util.RedisUtil;
+import com.ssafy.jjtrip.domain.friend.dto.response.SimpleUserInfoDto;
+import com.ssafy.jjtrip.domain.friend.service.FriendService;
 import com.ssafy.jjtrip.domain.search.service.TripLogSearchService;
 import com.ssafy.jjtrip.domain.trip.entity.Trip;
 import com.ssafy.jjtrip.domain.trip.service.TripService;
@@ -18,11 +21,18 @@ import com.ssafy.jjtrip.domain.triplog.exception.TripLogErrorCode;
 import com.ssafy.jjtrip.domain.triplog.exception.TripLogException;
 import com.ssafy.jjtrip.domain.triplog.mapper.TripLogMapper;
 import com.ssafy.jjtrip.domain.user.service.UserValidateService;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +47,11 @@ public class TripLogService {
     private final TripLogCommentService tripLogCommentService;
     private final TripLogLikeService tripLogLikeService;
     private final TripLogSearchService tripLogSearchService;
+    private final FriendService friendService;
+    private final RedisUtil redisUtil;
+
+    private static final String TIMELINE_KEY_PREFIX = "timeline:";
+    private static final int FRIEND_FEED_DAYS_THRESHOLD = 3;
 
     @Transactional
     public TripLogCreateResponseDto createTripLog(Long userId, TripLogCreateRequestDto requestDto) {
@@ -58,12 +73,56 @@ public class TripLogService {
         tripLogMapper.insertTripLog(tripLog);
         processAndSaveImages(tripLog.getId(), userId, requestDto.content());
 
-        // Sync ES
-        Trip trip = tripService.getTripDetail(requestDto.tripId(), userId);
-        List<String> imageUrls = extractImageUrls(tripLog.getContent());
-        tripLogSearchService.saveTripLog(tripLog, trip, imageUrls);
+        TripLog savedTripLog = tripLogMapper.findById(tripLog.getId())
+                .orElseThrow(() -> new TripLogException(TripLogErrorCode.LOG_NOT_FOUND));
 
-        return new TripLogCreateResponseDto(tripLog.getId());
+        Trip trip = tripService.getTripDetail(savedTripLog.getTripId(), userId);
+        List<String> imageUrls = extractImageUrls(savedTripLog.getContent());
+        tripLogSearchService.saveTripLog(savedTripLog, trip, imageUrls);
+
+        if (savedTripLog.getVisibility() == TripLogVisibility.PUBLIC) {
+            fanoutLogToFriendTimelines(userId, savedTripLog.getId(), savedTripLog.getCreatedAt());
+        }
+
+        return new TripLogCreateResponseDto(savedTripLog.getId());
+    }
+
+    public SliceDto<TripLogFeedResponseDto> getFriendTripLogFeed(Long userId, Long cursor, int limit, Long memberId) {
+        String timelineKey = TIMELINE_KEY_PREFIX + userId;
+
+        long nowMs = System.currentTimeMillis();
+        long minScore = nowMs - Duration.ofDays(FRIEND_FEED_DAYS_THRESHOLD).toMillis();
+        long maxScore = (cursor == null) ? Long.MAX_VALUE : cursor - 1;
+
+        int queryLimit = limit + 1;
+
+        Set<ZSetOperations.TypedTuple<String>> tuples =
+                redisUtil.zrevrangeByScoreWithScores(timelineKey, minScore, maxScore, 0, queryLimit);
+
+        if (tuples == null || tuples.isEmpty()) {
+            return new SliceDto<>(Collections.emptyList(), null, false);
+        }
+
+        List<ZSetOperations.TypedTuple<String>> tupleList = new ArrayList<>(tuples);
+
+        boolean hasNext = tupleList.size() > limit;
+        if (hasNext) {
+            tupleList = tupleList.subList(0, limit);
+        }
+
+        Long nextCursor = tupleList.isEmpty()
+                ? null
+                : tupleList.get(tupleList.size() - 1).getScore().longValue();
+
+        List<Long> logIds = tupleList.stream()
+                .map(t -> Long.valueOf(t.getValue()))
+                .toList();
+
+        List<TripLogFeedResponseDto.FeedData> tripLogsData = tripLogMapper.findLogsByIds(logIds, memberId);
+
+        List<TripLogFeedResponseDto> tripLogs = mapToTripLogFeedResponse(tripLogsData);
+
+        return new SliceDto<>(tripLogs, nextCursor, hasNext);
     }
 
     public SliceDto<TripLogFeedResponseDto> getTripLogFeed(Long cursor, int limit, Long memberId) {
@@ -135,8 +194,7 @@ public class TripLogService {
 
         return TripLogDetailResponseDto.from(baseInfo, images, comments, likeCount, commentCount);
     }
-    
-    // Private helper for extracting URLs to avoid duplicating regex logic
+
     private List<String> extractImageUrls(String content) {
         if (content == null || content.isBlank()) return Collections.emptyList();
         List<String> urls = new java.util.ArrayList<>();
@@ -151,7 +209,7 @@ public class TripLogService {
     @Transactional
     public void updateTripLog(Long logId, Long userId, TripLogUpdateRequestDto requestDto) {
         validateLogAuthor(logId, userId);
-        
+
         TripLog tripLog = TripLog.builder()
                 .id(logId)
                 .title(requestDto.title())
@@ -165,10 +223,8 @@ public class TripLogService {
             tripLogMapper.deleteLogImages(logId);
             processAndSaveImages(logId, userId, requestDto.content());
         }
-        
-        // Sync ES
-        // Need full TripLog and Trip data
-        TripLog updatedLog = tripLogMapper.findById(logId).orElseThrow(); 
+
+        TripLog updatedLog = tripLogMapper.findById(logId).orElseThrow();
         Trip trip = tripService.getTripDetail(updatedLog.getTripId(), userId);
         List<String> imageUrls = extractImageUrls(updatedLog.getContent());
         tripLogSearchService.saveTripLog(updatedLog, trip, imageUrls);
@@ -179,15 +235,14 @@ public class TripLogService {
             return;
         }
 
-        // Markdown Image Pattern: ![alt](url)
         java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("!\\[.*?\\]\\((.*?)\\)");
         java.util.regex.Matcher matcher = pattern.matcher(content);
 
         int orderIndex = 0;
         while (matcher.find()) {
             String imageUrl = matcher.group(1);
-            String imageRefKey = "img_" + orderIndex; 
-            
+            String imageRefKey = "img_" + orderIndex;
+
             tripLogMapper.insertTripLogImage(new TripLogMapper.LogImageInsertInfo(
                     logId, userId, imageUrl, orderIndex++, imageRefKey
             ));
@@ -209,6 +264,7 @@ public class TripLogService {
             throw new TripLogException(TripLogErrorCode.FORBIDDEN_ACCESS);
         }
     }
+
     private List<TripLogFeedResponseDto> mapToTripLogFeedResponse(List<TripLogFeedResponseDto.FeedData> tripLogsData) {
         if (tripLogsData.isEmpty()) {
             return Collections.emptyList();
@@ -229,5 +285,16 @@ public class TripLogService {
         return tripLogsData.stream()
                 .map(data -> TripLogFeedResponseDto.from(data, imagesByLogId.getOrDefault(data.logId(), Collections.emptyList())))
                 .toList();
+    }
+
+    @Async
+    public void fanoutLogToFriendTimelines(Long authorId, Long logId, LocalDateTime createdAt) {
+        List<SimpleUserInfoDto> friends = friendService.getFriendList(authorId);
+        double score = createdAt.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+
+        for (SimpleUserInfoDto friend : friends) {
+            String timelineKey = TIMELINE_KEY_PREFIX + friend.getUserId();
+            redisUtil.zadd(timelineKey, String.valueOf(logId), score);
+        }
     }
 }


### PR DESCRIPTION
## Issue
- #55 

## Details
이 PR은 **친구 피드 조회 API를 구현**했습니다.
단순히 DB에서 조회하는 방식이 아닌, **Redis 기반의 fan-out 전략을 활용하여 읽기 성능을 보장**하고 있습니다.

### ✔️ 주요 변경 사항
**친구 피드 조회 API를 구현**했습니다. 최근 3일 간의 데이터만 반환됩니다.
`TripLogService`의 `getFriendTripLogFeed` 메서드는 Redis ZSET score 기반의 커서를 활용하여 무한 스크롤을 지원합니다.

---

### 📘 API 명세
GET `/api/feed/friends`
  - **성공 (`200 OK`)**
  - **파라미터 타입 불일치 등 잘못된 요청 (`400 Bad Request`)**
  - **유효하지 않은 토큰 (`401 Unauthorized`)**
  - **잘못된 URL 경로로 접근할 때 (`404 Not Found`)**
  - **DB/Redis 장애, 비로그인 접근 시 NPE (`500 Internal Server Error`)**

---

### 🚧 특이사항
1. 타임라인에 쌓이는 데이터를 정리하는 로직이 부재합니다. **오래된 데이터를 삭제하는 로직이 필요**합니다.
2. 친구 목록을 돌면서 **각 친구마다 `zadd`를 호출**하고 있습니다. **Redis pipeline**으로 모든 친구에 대한 `zadd` 호출을 묶어서 보냄으로써 네트워크/Redis CPU의 부담을 줄일 수 있습니다.
3. LOG를 삭제하거나 비공개(PRIVATE)로 전환하면, DB에서는 삭제되지만 Redis에서는 logId가 남게 됩니다. **정합성을 맞춰주기 위한 개선이 필요**합니다.
4. **좋아요/댓글 갯수, 친구 목록 등도 Redis로 관리**하여 성능을 향상시킬 수 있습니다.
 
---

### 📅 향후 계획
- **Redis 관리 로직 추가 및 성능 개선 작업이 필요**합니다.