### PR TITLE
feat: 구글맵스 api 활용 장소 썸네일 저장

### DIFF
--- a/docker-compose.server-build.yml
+++ b/docker-compose.server-build.yml
@@ -29,6 +29,7 @@ services:
       AWS_BUCKET_NAME: ${AWS_BUCKET_NAME}
 
       OPEN_AI_API_KEY: ${OPEN_AI_API_KEY}
+      GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}
 
     depends_on:
       mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       AWS_BUCKET_NAME: ${AWS_BUCKET_NAME}
 
       OPEN_AI_API_KEY: ${OPEN_AI_API_KEY}
+      GOOGLE_MAPS_API_KEY: ${GOOGLE_MAPS_API_KEY}
 
     depends_on:
       mysql:

--- a/src/main/java/com/ssafy/jjtrip/common/google/GoogleMapsClient.java
+++ b/src/main/java/com/ssafy/jjtrip/common/google/GoogleMapsClient.java
@@ -1,0 +1,81 @@
+package com.ssafy.jjtrip.common.google;
+
+import com.ssafy.jjtrip.common.google.dto.GoogleMapsDto.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleMapsClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${google.maps.api-key}")
+    private String apiKey;
+
+    private static final String SEARCH_URL = "https://places.googleapis.com/v1/places:searchText";
+    private static final String MEDIA_URL_TEMPLATE = "https://places.googleapis.com/v1/%s/media?key=%s&skipHttpRedirect=true&maxHeightPx=400&maxWidthPx=400";
+
+    public Place searchPlace(String name, BigDecimal lat, BigDecimal lng) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("X-Goog-Api-Key", apiKey);
+            headers.set("X-Goog-FieldMask", "places.name,places.photos");
+
+            SearchPlaceRequest request = new SearchPlaceRequest(
+                    name,
+                    "ko",
+                    LocationBias.of(lat, lng, 500.0) // 500m radius bias
+            );
+
+            HttpEntity<SearchPlaceRequest> entity = new HttpEntity<>(request, headers);
+
+            ResponseEntity<SearchPlaceResponse> response = restTemplate.exchange(
+                    SEARCH_URL,
+                    HttpMethod.POST,
+                    entity,
+                    SearchPlaceResponse.class
+            );
+
+            if (response.getBody() != null && response.getBody().places() != null && !response.getBody().places().isEmpty()) {
+                return response.getBody().places().get(0);
+            }
+        } catch (Exception e) {
+            log.error("Google Maps Places Search failed: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    public byte[] fetchPhoto(String photoResourceName) {
+        try {
+            // 1. Get the actual download URL (since we use skipHttpRedirect=true for metadata if needed, but here we want bytes directly)
+            // Actually, to get bytes directly we can just not use skipHttpRedirect or handle the redirect.
+            // Google Places Photo API returns a 302 redirect to the image URL.
+            // RestTemplate follows redirects by default usually, but let's check the API spec.
+            // "If you skip the redirect... the response contains a JSON object with a name and photoUri."
+            // We want the actual image bytes. So we should NOT skip redirect, OR we fetch the URI and download.
+            // Let's try downloading directly.
+
+            String url = String.format("https://places.googleapis.com/v1/%s/media?key=%s&maxHeightPx=800&maxWidthPx=800", photoResourceName, apiKey);
+            
+            return restTemplate.getForObject(url, byte[].class);
+
+        } catch (Exception e) {
+            log.error("Failed to fetch photo from Google Maps: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/ssafy/jjtrip/common/google/dto/GoogleMapsDto.java
+++ b/src/main/java/com/ssafy/jjtrip/common/google/dto/GoogleMapsDto.java
@@ -1,0 +1,46 @@
+package com.ssafy.jjtrip.common.google.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class GoogleMapsDto {
+
+    public record SearchPlaceRequest(
+            String textQuery,
+            String languageCode,
+            LocationBias locationBias
+    ) {}
+
+    public record LocationBias(
+            Circle circle
+    ) {
+        public static LocationBias of(BigDecimal lat, BigDecimal lng, double radius) {
+            return new LocationBias(new Circle(new Center(lat, lng), radius));
+        }
+    }
+
+    public record Circle(
+            Center center,
+            double radius
+    ) {}
+
+    public record Center(
+            BigDecimal latitude,
+            BigDecimal longitude
+    ) {}
+
+    public record SearchPlaceResponse(
+            List<Place> places
+    ) {}
+
+    public record Place(
+            String name,
+            List<Photo> photos
+    ) {}
+
+    public record Photo(
+            String name,
+            Integer widthPx,
+            Integer heightPx
+    ) {}
+}

--- a/src/main/java/com/ssafy/jjtrip/common/s3/S3Provider.java
+++ b/src/main/java/com/ssafy/jjtrip/common/s3/S3Provider.java
@@ -95,6 +95,29 @@ public class S3Provider {
         return baseUrl + "/" + key;
     }
 
+    public String upload(byte[] content, String originalFilename, String contentType, String prefix) {
+        if (content == null || content.length == 0) {
+            throw new FileException(FileErrorCode.EMPTY_FILE);
+        }
+
+        String key = createKey(prefix, originalFilename);
+
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(contentType)
+                    .contentLength((long) content.length)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(content));
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        return baseUrl + "/" + key;
+    }
+
     public void deleteImage(String imageUrl) {
         if (imageUrl == null || imageUrl.isEmpty() || !imageUrl.startsWith(baseUrl)) {
             return;

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/controller/SpotController.java
@@ -58,6 +58,12 @@ public class SpotController {
         return ResponseEntity.ok(SpotResponseDto.from(updatedSpot));
     }
 
+    @PostMapping("/{spotId}/thumbnail")
+    public ResponseEntity<SpotResponseDto> updateSpotThumbnail(@PathVariable Long spotId) {
+        Spot updatedSpot = spotService.updateSpotThumbnailWithGoogle(spotId);
+        return ResponseEntity.ok(SpotResponseDto.from(updatedSpot));
+    }
+
     @DeleteMapping("/{spotId}")
     public ResponseEntity<Void> deleteSpot(@PathVariable Long spotId) {
         spotService.deleteSpot(spotId);

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
@@ -1,7 +1,6 @@
 package com.ssafy.jjtrip.domain.spot.service;
 
 import com.ssafy.jjtrip.common.google.GoogleMapsClient;
-import com.ssafy.jjtrip.common.google.dto.GoogleMapsDto.Photo;
 import com.ssafy.jjtrip.common.google.dto.GoogleMapsDto.Place;
 import com.ssafy.jjtrip.common.s3.S3Provider;
 import com.ssafy.jjtrip.domain.spot.dto.SpotUpsertResult;
@@ -108,26 +107,47 @@ public class SpotService {
     }
 
     private void enrichSpotWithGoogleImage(Spot spot) {
-        if (spot.getThumbnailUrl() != null && !spot.getThumbnailUrl().isBlank()) {
-            return;
-        }
+        if (hasThumbnail(spot)) return;
 
+        byte[] imageBytes = fetchGooglePlaceImage(spot);
+        if (imageBytes == null || imageBytes.length == 0) return;
+
+        String uploadedUrl = uploadImageToS3(spot, imageBytes);
+        if (uploadedUrl != null) {
+            spot.setThumbnailUrl(uploadedUrl);
+            log.info("Successfully uploaded Google Maps photo to S3: {}", uploadedUrl);
+        }
+    }
+
+    private byte[] fetchGooglePlaceImage(Spot spot) {
         try {
             log.info("Fetching photo from Google Maps for spot: {}", spot.getName());
             Place place = googleMapsClient.searchPlace(spot.getName(), spot.getLat(), spot.getLng());
             
             if (place != null && place.photos() != null && !place.photos().isEmpty()) {
-                Photo photo = place.photos().get(0);
-                byte[] imageBytes = googleMapsClient.fetchPhoto(photo.name());
-                
-                if (imageBytes != null && imageBytes.length > 0) {
-                    String uploadedUrl = s3Provider.upload(imageBytes, spot.getName() + ".jpg", "image/jpeg", "spots/" + spot.getKakaoPlaceId() + "/");
-                    spot.setThumbnailUrl(uploadedUrl);
-                    log.info("Successfully uploaded Google Maps photo to S3: {}", uploadedUrl);
-                }
+                return googleMapsClient.fetchPhoto(place.photos().get(0).name());
             }
         } catch (Exception e) {
-            log.error("Failed to enrich spot with Google Image: {}", e.getMessage());
+            log.error("Failed to fetch Google Place image: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    private boolean hasThumbnail(Spot spot) {
+        return spot.getThumbnailUrl() != null && !spot.getThumbnailUrl().isBlank();
+    }
+
+    private String uploadImageToS3(Spot spot, byte[] imageBytes) {
+        try {
+            return s3Provider.upload(
+                imageBytes, 
+                spot.getName() + ".jpg", 
+                "image/jpeg", 
+                "spots/" + spot.getKakaoPlaceId() + "/"
+            );
+        } catch (Exception e) {
+            log.error("Failed to upload image to S3: {}", e.getMessage());
+            return null;
         }
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
@@ -1,5 +1,9 @@
 package com.ssafy.jjtrip.domain.spot.service;
 
+import com.ssafy.jjtrip.common.google.GoogleMapsClient;
+import com.ssafy.jjtrip.common.google.dto.GoogleMapsDto.Photo;
+import com.ssafy.jjtrip.common.google.dto.GoogleMapsDto.Place;
+import com.ssafy.jjtrip.common.s3.S3Provider;
 import com.ssafy.jjtrip.domain.spot.dto.SpotUpsertResult;
 import com.ssafy.jjtrip.domain.spot.entity.Spot;
 import com.ssafy.jjtrip.domain.spot.exception.SpotErrorCode;
@@ -21,12 +25,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class SpotService {
 
     private final SpotMapper spotMapper;
+    private final S3Provider s3Provider;
+    private final GoogleMapsClient googleMapsClient;
 
 
     public Spot createSpot(Spot spot) {
         if (spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId()).isPresent()) {
             throw new SpotException(SpotErrorCode.ALREADY_EXISTS);
         }
+        
+        enrichSpotWithGoogleImage(spot);
+        
         spotMapper.insert(spot);
         return spot;
     }
@@ -59,6 +68,7 @@ public class SpotService {
     public Spot findOrCreate(Spot spot) {
         return spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId())
                 .orElseGet(() -> {
+                    enrichSpotWithGoogleImage(spot);
                     spotMapper.insert(spot);
                     return spot;
                 });
@@ -68,6 +78,7 @@ public class SpotService {
         return spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId())
                 .map(existingSpot -> new SpotUpsertResult(existingSpot, false))
                 .orElseGet(() -> {
+                    enrichSpotWithGoogleImage(spot);
                     spotMapper.insert(spot);
                     return new SpotUpsertResult(spot, true);
                 });
@@ -94,5 +105,29 @@ public class SpotService {
     @CacheEvict(value = "hotPlaces", allEntries = true)
     public void evictHotPlacesCache() {
         log.info("Hot Place 캐시가 갱신되었습니다.");
+    }
+
+    private void enrichSpotWithGoogleImage(Spot spot) {
+        if (spot.getThumbnailUrl() != null && !spot.getThumbnailUrl().isBlank()) {
+            return;
+        }
+
+        try {
+            log.info("Fetching photo from Google Maps for spot: {}", spot.getName());
+            Place place = googleMapsClient.searchPlace(spot.getName(), spot.getLat(), spot.getLng());
+            
+            if (place != null && place.photos() != null && !place.photos().isEmpty()) {
+                Photo photo = place.photos().get(0);
+                byte[] imageBytes = googleMapsClient.fetchPhoto(photo.name());
+                
+                if (imageBytes != null && imageBytes.length > 0) {
+                    String uploadedUrl = s3Provider.upload(imageBytes, spot.getName() + ".jpg", "image/jpeg", "spots/" + spot.getKakaoPlaceId() + "/");
+                    spot.setThumbnailUrl(uploadedUrl);
+                    log.info("Successfully uploaded Google Maps photo to S3: {}", uploadedUrl);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Failed to enrich spot with Google Image: {}", e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/spot/service/SpotService.java
@@ -27,18 +27,6 @@ public class SpotService {
     private final S3Provider s3Provider;
     private final GoogleMapsClient googleMapsClient;
 
-
-    public Spot createSpot(Spot spot) {
-        if (spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId()).isPresent()) {
-            throw new SpotException(SpotErrorCode.ALREADY_EXISTS);
-        }
-        
-        enrichSpotWithGoogleImage(spot);
-        
-        spotMapper.insert(spot);
-        return spot;
-    }
-
     public Spot getSpotById(Long spotId) {
         return spotMapper.findById(spotId)
                 .orElseThrow(() -> new SpotException(SpotErrorCode.SPOT_NOT_FOUND));
@@ -67,7 +55,6 @@ public class SpotService {
     public Spot findOrCreate(Spot spot) {
         return spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId())
                 .orElseGet(() -> {
-                    enrichSpotWithGoogleImage(spot);
                     spotMapper.insert(spot);
                     return spot;
                 });
@@ -77,7 +64,6 @@ public class SpotService {
         return spotMapper.findByKakaoPlaceId(spot.getKakaoPlaceId())
                 .map(existingSpot -> new SpotUpsertResult(existingSpot, false))
                 .orElseGet(() -> {
-                    enrichSpotWithGoogleImage(spot);
                     spotMapper.insert(spot);
                     return new SpotUpsertResult(spot, true);
                 });
@@ -106,17 +92,21 @@ public class SpotService {
         log.info("Hot Place 캐시가 갱신되었습니다.");
     }
 
-    private void enrichSpotWithGoogleImage(Spot spot) {
-        if (hasThumbnail(spot)) return;
+    public Spot updateSpotThumbnailWithGoogle(Long spotId) {
+        Spot spot = getSpotById(spotId);
+        
+        if (hasThumbnail(spot)) return spot;
 
         byte[] imageBytes = fetchGooglePlaceImage(spot);
-        if (imageBytes == null || imageBytes.length == 0) return;
+        if (imageBytes == null || imageBytes.length == 0) return spot;
 
         String uploadedUrl = uploadImageToS3(spot, imageBytes);
         if (uploadedUrl != null) {
             spot.setThumbnailUrl(uploadedUrl);
-            log.info("Successfully uploaded Google Maps photo to S3: {}", uploadedUrl);
+            spotMapper.update(spot);
+            log.info("Successfully updated spot thumbnail via Google Maps: {}", uploadedUrl);
         }
+        return spot;
     }
 
     private byte[] fetchGooglePlaceImage(Spot spot) {


### PR DESCRIPTION
## Issue
- close #102 

## Details
<img width="400" height="" alt="image" src="https://github.com/user-attachments/assets/557765d4-2d73-41e2-9619-78d8c4eae176" />

- 구글 Places API를 활용하여 장소 썸네일을 저장했습니다.
- 썸네일 생성 요청 시 썸네일이 db에 없었다면 구글 Places API를 호출해 이미지를 받고, S3 서버에 올린 다음 db에는 url을 저장합니다.
- 처음엔 장소 정보 생성 로직에서 이미지 호출, 저장 로직까지 한꺼번에 처리했었습니다.
- 그런데 이렇게 하니 이미지 저장에 시간이 걸리는데 다 끝날 때까지 클라이언트로 응답이 가지 않아 사용자 경험이 나빠지게 됐습니다.
- 이에 이미지 생성 api는 분리해 이미지가 없는 상태로 기본 정보는 반환하고,
- 이후에 클라이언트에서 썸네일 생성 요청이 오면 생성 후 반환하도록 했습니다.
- 한 번 썸네일이 저장되고 나면, 클라이언트에서 요청이 와도 기존에 있는 이미지 url을 돌려주면 됩니다.