### PR TITLE
fix: 알림 시간 표시 및 읽음 처리 오류 수정

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/notification/dto/NotificationResponseDto.java
@@ -1,5 +1,6 @@
 package com.ssafy.jjtrip.domain.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ssafy.jjtrip.domain.notification.entity.Notification;
 import com.ssafy.jjtrip.domain.notification.entity.NotificationType;
 import lombok.Builder;
@@ -12,13 +13,16 @@ import java.time.LocalDateTime;
 public class NotificationResponseDto {
     private Long id;
     private Long senderId;
-    private String senderNickname; // To display sender's name
-    private String senderProfileImageUrl; // Optional: To display sender's profile image
+    private String senderNickname;
+    private String senderProfileImageUrl;
     private NotificationType type;
     private String message;
     private Long targetId;
     private String targetUrl;
+    
+    @JsonProperty("isRead")
     private boolean isRead;
+    
     private LocalDateTime createdAt;
 
     public static NotificationResponseDto from(Notification notification, String senderNickname, String senderProfileImageUrl) {

--- a/src/main/java/com/ssafy/jjtrip/domain/notification/entity/Notification.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/notification/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.ssafy.jjtrip.domain.notification.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import java.time.LocalDateTime;
 
@@ -14,8 +15,11 @@ public class Notification {
     private Long senderId;
     private NotificationType type;
     private String message;
-    private Long targetId;    // TripLog ID, Trip ID, or User ID
-    private String targetUrl; // Frontend direct link
+    private Long targetId;
+    private String targetUrl;
+    
+    @JsonProperty("isRead")
     private boolean isRead;
+    
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/notification/mapper/NotificationMapper.java
@@ -9,7 +9,7 @@ import java.util.List;
 public interface NotificationMapper {
 
     @Insert("INSERT INTO notification (receiver_id, sender_id, type, message, target_id, target_url, is_read, created_at) " +
-            "VALUES (#{receiverId}, #{senderId}, #{type}, #{message}, #{targetId}, #{targetUrl}, #{isRead}, NOW())")
+            "VALUES (#{receiverId}, #{senderId}, #{type}, #{message}, #{targetId}, #{targetUrl}, #{isRead}, #{createdAt})")
     @Options(useGeneratedKeys = true, keyProperty = "id")
     void save(Notification notification);
 

--- a/src/main/java/com/ssafy/jjtrip/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/notification/service/NotificationService.java
@@ -78,6 +78,7 @@ public class NotificationService {
                 .targetId(targetId)
                 .targetUrl(targetUrl)
                 .isRead(false)
+                .createdAt(java.time.LocalDateTime.now())
                 .build();
         
         notificationMapper.save(notification);


### PR DESCRIPTION
## Issue
이 PR은 **알림 도착 시간 표시 및 읽음 처리에 관한 오류를 수정**했습니다.

## Details
알림이 도착하면 1970-01-01에 송신된 알림으로 뜨는 오류가 있었습니다.
읽음 처리를 했음에도 새로고침을 하면 읽지 않음 상태로 되돌아가는 오류가 있었습니다.

### ✔️ 주요 변경 사항
Notification의 `createdAt` 항목이 제대로 포함되도록 수정했습니다.
Jackson 라이브러리에서 JSON으로 변환할 때 변수명을 명시적으로 선언하여 읽음 처리에 대한 이슈를 해결했습니다.