### PR TITLE
feat: 친구 수 계산 로직 구현

### DIFF
--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -98,6 +98,10 @@ public class FriendService {
                 .build();
         friendMapper.saveFriendship(friendship);
 
+        // 양쪽 유저의 친구 수 증가
+        userMapper.incrementFriendsCount(friendRequest.getRequesterId());
+        userMapper.incrementFriendsCount(friendRequest.getReceiverId());
+
         notificationService.send(acceptingUserId, friendRequest.getRequesterId(), NotificationType.FRIEND_ACCEPT, null, acceptingUserId, "/friends");
 
         // 친구 요청 기록 삭제
@@ -150,5 +154,9 @@ public class FriendService {
 
         // 3. 친구 관계 삭제
         friendMapper.deleteFriendship(userIdA, userIdB);
+
+        // 양쪽 유저의 친구 수 감소
+        userMapper.decrementFriendsCount(myUserId);
+        userMapper.decrementFriendsCount(friendId);
     }
 }

--- a/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/friend/service/FriendService.java
@@ -11,6 +11,7 @@ import com.ssafy.jjtrip.domain.friend.mapper.FriendMapper;
 import com.ssafy.jjtrip.domain.notification.entity.NotificationType;
 import com.ssafy.jjtrip.domain.notification.service.NotificationService;
 import com.ssafy.jjtrip.domain.user.mapper.UserMapper;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,12 @@ public class FriendService {
     private final FriendMapper friendMapper;
     private final UserMapper userMapper;
     private final NotificationService notificationService;
+
+    @PostConstruct
+    @Transactional
+    public void init() {
+        userMapper.syncAllFriendsCounts();
+    }
 
     @Transactional
     public void sendRequest(Long requesterId, Long receiverId) {

--- a/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
@@ -141,6 +141,13 @@ public interface UserMapper {
             "SELECT COUNT(*) FROM friendship f WHERE f.user_id_a = up.user_id OR f.user_id_b = up.user_id)")
     void syncAllFriendsCounts();
 
+    @Update("UPDATE user_profile SET friends_count = friends_count + 1 WHERE user_id = #{userId}")
+    void incrementFriendsCount(@Param("userId") Long userId);
+
+    @Update("UPDATE user_profile SET friends_count = GREATEST(friends_count - 1, 0) WHERE user_id = #{userId}")
+    void decrementFriendsCount(@Param("userId") Long userId);
+
+
 
     @Select("SELECT id, nickname, profile_image_url " +
             "FROM user WHERE nickname LIKE CONCAT('%', #{nickname}, '%')")

--- a/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ssafy/jjtrip/domain/user/mapper/UserMapper.java
@@ -137,6 +137,11 @@ public interface UserMapper {
     @Update("UPDATE user_profile SET travel_style_summary = #{summary} WHERE user_id = #{userId}")
     void updateTravelStyleSummary(@Param("userId") Long userId, @Param("summary") String summary);
 
+    @Update("UPDATE user_profile up SET friends_count = (" +
+            "SELECT COUNT(*) FROM friendship f WHERE f.user_id_a = up.user_id OR f.user_id_b = up.user_id)")
+    void syncAllFriendsCounts();
+
+
     @Select("SELECT id, nickname, profile_image_url " +
             "FROM user WHERE nickname LIKE CONCAT('%', #{nickname}, '%')")
     @Results({


### PR DESCRIPTION
## Issue
- #115 

## Details
이 PR은 **친구 수 계산 로직을 구현**했습니다.

### ✔️ 주요 변경 사항
애플리케이션 실행 시점에 데이터 정합성을 맞춰줄 `init()` 메서드를 구현했습니다.
친구 수락 및 삭제에 따른 친구 수 변동을 위해 매퍼 함수를 구현하여 호출합니다.