### PR TITLE
feat(deploy): Nginx 프론트엔드/백엔드 리버스 프록시  설정 적용

### DIFF
--- a/deploy/nginx/conf.d/default.conf
+++ b/deploy/nginx/conf.d/default.conf
@@ -11,7 +11,7 @@ server {
     ssl_certificate     /etc/letsencrypt/live/tritt.o-r.kr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/tritt.o-r.kr/privkey.pem;
 
-    location / {
+    location /api/ {
         proxy_pass http://app:8080;
         proxy_http_version 1.1;
 
@@ -19,5 +19,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
+    }
+
+    location / {
+        resolver 8.8.8.8;
+        proxy_pass https://frontend-ten-navy-51.vercel.app;
+        proxy_ssl_server_name on;
+        proxy_set_header Host frontend-ten-navy-51.vercel.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }


### PR DESCRIPTION
## Issue
- 단일 도메인 처리

## Details

### 📌 개요
운영 서버의 Nginx 리버스 프록시 설정을 변경하여, 단일 도메인(`tritt.o-r.kr`)에서 프론트엔드(Vercel)와 백엔드 서비스를 모두 처리할 수 있도록 구성했습니다.
### 📝 변경 사항
- **deploy/nginx/conf.d/default.conf**
  - **`location /`**: 모든 일반 요청을 Vercel 배포 주소(`https://frontend-ten-navy-51.vercel.app`)로 전달합니다.
  - **`location /api/`**: API 요청만 선별하여 백엔드 컨테이너(`http://app:8080`)로 전달합니다.
  - **안정성 확보**: Vercel 프록시 시 발생할 수 있는 502 에러 방지를 위해 Google DNS Resolver(`8.8.8.8`)와 `proxy_ssl_server_name` 옵션을 적용했습니다.
### ✅ 테스트 결과
- 서버(`tritt.o-r.kr`) 접속 시 Vercel 프론트엔드 화면이 정상적으로 로드됨.
- `/api` 경로 호출 시 백엔드 서버가 정상적으로 응답함.
